### PR TITLE
Update to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+## 2.0
+
+  - Update pay-out version to 2.0
+    - mondido.payment.js and multi.css will follow pay-out version.
+      If "pay-out" is 2.1 "mondido.payment.js" and "multi.css" shuld be of version 2.1.x
+      Example "mondido.payment.js" is of version 2.1.x.x it should be compatible with "pay-out" version to 2.1.x
+  - Add MIT License
+  - Move changelog
+  - Fix wc3 validation
+  - Fix css/js bugs
+  - Update images
+  - Add metadata preload data
+  - Add convertCurrency
+  - Update CSS
+  - Update JS
+  - Change/Update design
+  - Change Enter to tab if @ input
+  - Use liquid to only load the necessary html code
+  - Add liquid settings from mondido to easy setup
+  - Optimization
+  - convention
+  - Start to use css class convention (.mo-exaple-ex2-test)
+  - Start to use indent spaces 2 and
+  - Use transaction.merchant.settings_hosted 4 settings
+
+  ## 1.4.1
+
+  - Add AgreementCode setting
+  - Add logo alternative
+  - Move all image to load from mondido cdn
+  - Update endpoints
+  - Fix css/js bugs
+
+  ## 1.4
+
+  - Add masterpass
+  - Fix css/js bugs
+
+  ## 1.3.1
+
+  - Fix css/js bugs
+  - Add update translations
+  - Add more config options
+  - Add fontawesome
+  - Update invoice implementation
+
+  ## 1.1
+
+  - Added css, js files to repo
+  - Fixed bugs with hiding/showing paybutton and loader

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2015 Mondido Payments AB
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,30 +3,3 @@ https://www.mondido.com/en
 
 ## Templates
 html/pay-out.html
-
-Changelog
-
-- v1.4.1
-- Add AgreementCode setting
-- Add logo alternative
-- Move all image to load from mondido cdn
-- Update endpoints
-- Fix css/js bugs
-
-- v1.4
-- Add masterpass
-- Fix css/js bugs
-
-- v1.3.1
-- Fix css/js bugs
-- Add update translations
-- Add more config options
-- Add fontawesome
-- Update invoice implementation
-
-- V1.1
-- Added css, js files to repo
-- Fixed bugs with hiding/showing paybutton and loader
-
-This is a multi language, multi payment template that allow payments for cards, swish, paypal, trustly and invoice.
-

--- a/html/css/multi.css
+++ b/html/css/multi.css
@@ -1,533 +1,363 @@
-/* 
-
-Mondido PayOut style v1.7.3, (c) Mondido Payments AB 2016, hello@mondido.com
-
-*/
-
-
+/* Mondido PayOut style v2.0, (c) Mondido Payments AB 2016, hello@mondido.com */
 
 /*!
- * Bootstrap v3.0.0
- *
- * Copyright 2013 Twitter, Inc
- * Licensed under the Apache License v2.0
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Designed and built with all the love in the world by @mdo and @fat.
- *//*! normalize.css v2.1.0 | MIT License | git.io/normalize */article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}audio,canvas,video{display:inline-block}audio:not([controls]){display:none;height:0}[hidden]{display:none}html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}body{margin:0}a:focus{outline:thin dotted}a:active,a:hover{outline:0}h1{margin:.67em 0;font-size:2em}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}dfn{font-style:italic}hr{height:0;-moz-box-sizing:content-box;box-sizing:content-box}mark{color:#000;background:#ff0}code,kbd,pre,samp{font-family:monospace,serif;font-size:1em}pre{white-space:pre-wrap}q{quotes:"\201C" "\201D" "\2018" "\2019"}small{font-size:80%}sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:0}fieldset{padding:.35em .625em .75em;margin:0 2px;border:1px solid #c0c0c0}legend{padding:0;border:0}button,input,select,textarea{margin:0;font-family:inherit;font-size:100%}button,input{line-height:normal}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{cursor:pointer;-webkit-appearance:button}button[disabled],html input[disabled]{cursor:default}input[type="checkbox"],input[type="radio"]{padding:0;box-sizing:border-box}input[type="search"]{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-appearance:textfield}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0}textarea{overflow:auto;vertical-align:top}table{border-collapse:collapse;border-spacing:0}@media print{*{color:#000!important;text-shadow:none!important;background:transparent!important;box-shadow:none!important}a,a:visited{text-decoration:underline}a[href]:after{content:" (" attr(href) ")"}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100%!important}@page{margin:2cm .5cm}p,h2,h3{orphans:3;widows:3}h2,h3{page-break-after:avoid}.navbar{display:none}.table td,.table th{background-color:#fff!important}.btn>.caret,.dropup>.btn>.caret{border-top-color:#000!important}.label{border:1px solid #000}.table{border-collapse:collapse!important}.table-bordered th,.table-bordered td{border:1px solid #ddd!important}}*,*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}html{font-size:62.5%;-webkit-tap-highlight-color:rgba(0,0,0,0)}body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line-height:1.428571429;color:#333;background-color:#fff}input,button,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}button,input,select[multiple],textarea{background-image:none}a{color:#428bca;text-decoration:none}a:hover,a:focus{color:#2a6496;text-decoration:underline}a:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}img{vertical-align:middle}.img-responsive{display:block;height:auto;max-width:100%}.img-rounded{border-radius:6px}.img-thumbnail{display:inline-block;height:auto;max-width:100%;padding:4px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.img-circle{border-radius:50%}hr{margin-top:20px;margin-bottom:20px;border:0;border-top:1px solid #eee}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);border:0}p{margin:0 0 10px}.lead{margin-bottom:20px;font-size:16.099999999999998px;font-weight:200;line-height:1.4}@media(min-width:768px){.lead{font-size:21px}}small{font-size:85%}cite{font-style:normal}.text-muted{color:#999}.text-primary{color:#428bca}.text-warning{color:#c09853}.text-danger{color:#b94a48}.text-success{color:#468847}.text-info{color:#3a87ad}.text-left{text-align:left}.text-right{text-align:right}.text-center{text-align:center}h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-weight:500;line-height:1.1}h1 small,h2 small,h3 small,h4 small,h5 small,h6 small,.h1 small,.h2 small,.h3 small,.h4 small,.h5 small,.h6 small{font-weight:normal;line-height:1;color:#999}h1,h2,h3{margin-top:20px;margin-bottom:10px}h4,h5,h6{margin-top:10px;margin-bottom:10px}h1,.h1{font-size:36px}h2,.h2{font-size:30px}h3,.h3{font-size:24px}h4,.h4{font-size:18px}h5,.h5{font-size:14px}h6,.h6{font-size:12px}h1 small,.h1 small{font-size:24px}h2 small,.h2 small{font-size:18px}h3 small,.h3 small,h4 small,.h4 small{font-size:14px}.page-header{padding-bottom:9px;margin:40px 0 20px;border-bottom:1px solid #eee}ul,ol{margin-top:0;margin-bottom:10px}ul ul,ol ul,ul ol,ol ol{margin-bottom:0}.list-unstyled{padding-left:0;list-style:none}.list-inline{padding-left:0;list-style:none}.list-inline>li{display:inline-block;padding-right:5px;padding-left:5px}dl{margin-bottom:20px}dt,dd{line-height:1.428571429}dt{font-weight:bold}dd{margin-left:0}@media(min-width:768px){.dl-horizontal dt{float:left;width:160px;overflow:hidden;clear:left;text-align:right;text-overflow:ellipsis;white-space:nowrap}.dl-horizontal dd{margin-left:180px}.dl-horizontal dd:before,.dl-horizontal dd:after{display:table;content:" "}.dl-horizontal dd:after{clear:both}.dl-horizontal dd:before,.dl-horizontal dd:after{display:table;content:" "}.dl-horizontal dd:after{clear:both}}abbr[title],abbr[data-original-title]{cursor:help;border-bottom:1px dotted #999}abbr.initialism{font-size:90%;text-transform:uppercase}blockquote{padding:10px 20px;margin:0 0 20px;border-left:5px solid #eee}blockquote p{font-size:17.5px;font-weight:300;line-height:1.25}blockquote p:last-child{margin-bottom:0}blockquote small{display:block;line-height:1.428571429;color:#999}blockquote small:before{content:'\2014 \00A0'}blockquote.pull-right{padding-right:15px;padding-left:0;border-right:5px solid #eee;border-left:0}blockquote.pull-right p,blockquote.pull-right small{text-align:right}blockquote.pull-right small:before{content:''}blockquote.pull-right small:after{content:'\00A0 \2014'}q:before,q:after,blockquote:before,blockquote:after{content:""}address{display:block;margin-bottom:20px;font-style:normal;line-height:1.428571429}code,pre{font-family:Monaco,Menlo,Consolas,"Courier New",monospace}code{padding:2px 4px;font-size:90%;color:#c7254e;white-space:nowrap;background-color:#f9f2f4;border-radius:4px}pre{display:block;padding:9.5px;margin:0 0 10px;font-size:13px;line-height:1.428571429;color:#333;word-break:break-all;word-wrap:break-word;background-color:#f5f5f5;border:1px solid #ccc;border-radius:4px}pre.prettyprint{margin-bottom:20px}pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border:0}.pre-scrollable{max-height:340px;overflow-y:scroll}.container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto}.container:before,.container:after{display:table;content:" "}.container:after{clear:both}.container:before,.container:after{display:table;content:" "}.container:after{clear:both}.row{margin-right:-15px;margin-left:-15px}.row:before,.row:after{display:table;content:" "}.row:after{clear:both}.row:before,.row:after{display:table;content:" "}.row:after{clear:both}.col-xs-1,.col-xs-2,.col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xs-10,.col-xs-11,.col-xs-12,.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11,.col-sm-12,.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11,.col-md-12,.col-lg-1,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-lg-10,.col-lg-11,.col-lg-12{position:relative;min-height:1px;padding-right:15px;padding-left:15px}.col-xs-1,.col-xs-2,.col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xs-10,.col-xs-11{float:left}.col-xs-1{width:8.333333333333332%}.col-xs-2{width:16.666666666666664%}.col-xs-3{width:25%}.col-xs-4{width:33.33333333333333%}.col-xs-5{width:41.66666666666667%}.col-xs-6{width:50%}.col-xs-7{width:58.333333333333336%}.col-xs-8{width:66.66666666666666%}.col-xs-9{width:75%}.col-xs-10{width:83.33333333333334%}.col-xs-11{width:91.66666666666666%}.col-xs-12{width:100%}@media(min-width:768px){.container{max-width:750px}.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11{float:left}.col-sm-1{width:8.333333333333332%}.col-sm-2{width:16.666666666666664%}.col-sm-3{width:25%}.col-sm-4{width:33.33333333333333%}.col-sm-5{width:41.66666666666667%}.col-sm-6{width:50%}.col-sm-7{width:58.333333333333336%}.col-sm-8{width:66.66666666666666%}.col-sm-9{width:75%}.col-sm-10{width:83.33333333333334%}.col-sm-11{width:91.66666666666666%}.col-sm-12{width:100%}.col-sm-push-1{left:8.333333333333332%}.col-sm-push-2{left:16.666666666666664%}.col-sm-push-3{left:25%}.col-sm-push-4{left:33.33333333333333%}.col-sm-push-5{left:41.66666666666667%}.col-sm-push-6{left:50%}.col-sm-push-7{left:58.333333333333336%}.col-sm-push-8{left:66.66666666666666%}.col-sm-push-9{left:75%}.col-sm-push-10{left:83.33333333333334%}.col-sm-push-11{left:91.66666666666666%}.col-sm-pull-1{right:8.333333333333332%}.col-sm-pull-2{right:16.666666666666664%}.col-sm-pull-3{right:25%}.col-sm-pull-4{right:33.33333333333333%}.col-sm-pull-5{right:41.66666666666667%}.col-sm-pull-6{right:50%}.col-sm-pull-7{right:58.333333333333336%}.col-sm-pull-8{right:66.66666666666666%}.col-sm-pull-9{right:75%}.col-sm-pull-10{right:83.33333333333334%}.col-sm-pull-11{right:91.66666666666666%}.col-sm-offset-1{margin-left:8.333333333333332%}.col-sm-offset-2{margin-left:16.666666666666664%}.col-sm-offset-3{margin-left:25%}.col-sm-offset-4{margin-left:33.33333333333333%}.col-sm-offset-5{margin-left:41.66666666666667%}.col-sm-offset-6{margin-left:50%}.col-sm-offset-7{margin-left:58.333333333333336%}.col-sm-offset-8{margin-left:66.66666666666666%}.col-sm-offset-9{margin-left:75%}.col-sm-offset-10{margin-left:83.33333333333334%}.col-sm-offset-11{margin-left:91.66666666666666%}}@media(min-width:992px){.container{max-width:970px}.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11{float:left}.col-md-1{width:8.333333333333332%}.col-md-2{width:16.666666666666664%}.col-md-3{width:25%}.col-md-4{width:33.33333333333333%}.col-md-5{width:41.66666666666667%}.col-md-6{width:50%}.col-md-7{width:58.333333333333336%}.col-md-8{width:66.66666666666666%}.col-md-9{width:75%}.col-md-10{width:83.33333333333334%}.col-md-11{width:91.66666666666666%}.col-md-12{width:100%}.col-md-push-0{left:auto}.col-md-push-1{left:8.333333333333332%}.col-md-push-2{left:16.666666666666664%}.col-md-push-3{left:25%}.col-md-push-4{left:33.33333333333333%}.col-md-push-5{left:41.66666666666667%}.col-md-push-6{left:50%}.col-md-push-7{left:58.333333333333336%}.col-md-push-8{left:66.66666666666666%}.col-md-push-9{left:75%}.col-md-push-10{left:83.33333333333334%}.col-md-push-11{left:91.66666666666666%}.col-md-pull-0{right:auto}.col-md-pull-1{right:8.333333333333332%}.col-md-pull-2{right:16.666666666666664%}.col-md-pull-3{right:25%}.col-md-pull-4{right:33.33333333333333%}.col-md-pull-5{right:41.66666666666667%}.col-md-pull-6{right:50%}.col-md-pull-7{right:58.333333333333336%}.col-md-pull-8{right:66.66666666666666%}.col-md-pull-9{right:75%}.col-md-pull-10{right:83.33333333333334%}.col-md-pull-11{right:91.66666666666666%}.col-md-offset-0{margin-left:0}.col-md-offset-1{margin-left:8.333333333333332%}.col-md-offset-2{margin-left:16.666666666666664%}.col-md-offset-3{margin-left:25%}.col-md-offset-4{margin-left:33.33333333333333%}.col-md-offset-5{margin-left:41.66666666666667%}.col-md-offset-6{margin-left:50%}.col-md-offset-7{margin-left:58.333333333333336%}.col-md-offset-8{margin-left:66.66666666666666%}.col-md-offset-9{margin-left:75%}.col-md-offset-10{margin-left:83.33333333333334%}.col-md-offset-11{margin-left:91.66666666666666%}}@media(min-width:1200px){.container{max-width:1170px}.col-lg-1,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-lg-10,.col-lg-11{float:left}.col-lg-1{width:8.333333333333332%}.col-lg-2{width:16.666666666666664%}.col-lg-3{width:25%}.col-lg-4{width:33.33333333333333%}.col-lg-5{width:41.66666666666667%}.col-lg-6{width:50%}.col-lg-7{width:58.333333333333336%}.col-lg-8{width:66.66666666666666%}.col-lg-9{width:75%}.col-lg-10{width:83.33333333333334%}.col-lg-11{width:91.66666666666666%}.col-lg-12{width:100%}.col-lg-push-0{left:auto}.col-lg-push-1{left:8.333333333333332%}.col-lg-push-2{left:16.666666666666664%}.col-lg-push-3{left:25%}.col-lg-push-4{left:33.33333333333333%}.col-lg-push-5{left:41.66666666666667%}.col-lg-push-6{left:50%}.col-lg-push-7{left:58.333333333333336%}.col-lg-push-8{left:66.66666666666666%}.col-lg-push-9{left:75%}.col-lg-push-10{left:83.33333333333334%}.col-lg-push-11{left:91.66666666666666%}.col-lg-pull-0{right:auto}.col-lg-pull-1{right:8.333333333333332%}.col-lg-pull-2{right:16.666666666666664%}.col-lg-pull-3{right:25%}.col-lg-pull-4{right:33.33333333333333%}.col-lg-pull-5{right:41.66666666666667%}.col-lg-pull-6{right:50%}.col-lg-pull-7{right:58.333333333333336%}.col-lg-pull-8{right:66.66666666666666%}.col-lg-pull-9{right:75%}.col-lg-pull-10{right:83.33333333333334%}.col-lg-pull-11{right:91.66666666666666%}.col-lg-offset-0{margin-left:0}.col-lg-offset-1{margin-left:8.333333333333332%}.col-lg-offset-2{margin-left:16.666666666666664%}.col-lg-offset-3{margin-left:25%}.col-lg-offset-4{margin-left:33.33333333333333%}.col-lg-offset-5{margin-left:41.66666666666667%}.col-lg-offset-6{margin-left:50%}.col-lg-offset-7{margin-left:58.333333333333336%}.col-lg-offset-8{margin-left:66.66666666666666%}.col-lg-offset-9{margin-left:75%}.col-lg-offset-10{margin-left:83.33333333333334%}.col-lg-offset-11{margin-left:91.66666666666666%}}table{max-width:100%;background-color:transparent}th{text-align:left}.table{width:100%;margin-bottom:20px}.table thead>tr>th,.table tbody>tr>th,.table tfoot>tr>th,.table thead>tr>td,.table tbody>tr>td,.table tfoot>tr>td{padding:8px;line-height:1.428571429;vertical-align:top;border-top:1px solid #ddd}.table thead>tr>th{vertical-align:bottom;border-bottom:2px solid #ddd}.table caption+thead tr:first-child th,.table colgroup+thead tr:first-child th,.table thead:first-child tr:first-child th,.table caption+thead tr:first-child td,.table colgroup+thead tr:first-child td,.table thead:first-child tr:first-child td{border-top:0}.table tbody+tbody{border-top:2px solid #ddd}.table .table{background-color:#fff}.table-condensed thead>tr>th,.table-condensed tbody>tr>th,.table-condensed tfoot>tr>th,.table-condensed thead>tr>td,.table-condensed tbody>tr>td,.table-condensed tfoot>tr>td{padding:5px}.table-bordered{border:1px solid #ddd}.table-bordered>thead>tr>th,.table-bordered>tbody>tr>th,.table-bordered>tfoot>tr>th,.table-bordered>thead>tr>td,.table-bordered>tbody>tr>td,.table-bordered>tfoot>tr>td{border:1px solid #ddd}.table-bordered>thead>tr>th,.table-bordered>thead>tr>td{border-bottom-width:2px}.table-striped>tbody>tr:nth-child(odd)>td,.table-striped>tbody>tr:nth-child(odd)>th{background-color:#f9f9f9}.table-hover>tbody>tr:hover>td,.table-hover>tbody>tr:hover>th{background-color:#f5f5f5}table col[class*="col-"]{display:table-column;float:none}table td[class*="col-"],table th[class*="col-"]{display:table-cell;float:none}.table>thead>tr>td.active,.table>tbody>tr>td.active,.table>tfoot>tr>td.active,.table>thead>tr>th.active,.table>tbody>tr>th.active,.table>tfoot>tr>th.active,.table>thead>tr.active>td,.table>tbody>tr.active>td,.table>tfoot>tr.active>td,.table>thead>tr.active>th,.table>tbody>tr.active>th,.table>tfoot>tr.active>th{background-color:#f5f5f5}.table>thead>tr>td.success,.table>tbody>tr>td.success,.table>tfoot>tr>td.success,.table>thead>tr>th.success,.table>tbody>tr>th.success,.table>tfoot>tr>th.success,.table>thead>tr.success>td,.table>tbody>tr.success>td,.table>tfoot>tr.success>td,.table>thead>tr.success>th,.table>tbody>tr.success>th,.table>tfoot>tr.success>th{background-color:#dff0d8;border-color:#d6e9c6}.table-hover>tbody>tr>td.success:hover,.table-hover>tbody>tr>th.success:hover,.table-hover>tbody>tr.success:hover>td{background-color:#d0e9c6;border-color:#c9e2b3}.table>thead>tr>td.danger,.table>tbody>tr>td.danger,.table>tfoot>tr>td.danger,.table>thead>tr>th.danger,.table>tbody>tr>th.danger,.table>tfoot>tr>th.danger,.table>thead>tr.danger>td,.table>tbody>tr.danger>td,.table>tfoot>tr.danger>td,.table>thead>tr.danger>th,.table>tbody>tr.danger>th,.table>tfoot>tr.danger>th{background-color:#f2dede;border-color:#eed3d7}.table-hover>tbody>tr>td.danger:hover,.table-hover>tbody>tr>th.danger:hover,.table-hover>tbody>tr.danger:hover>td{background-color:#ebcccc;border-color:#e6c1c7}.table>thead>tr>td.warning,.table>tbody>tr>td.warning,.table>tfoot>tr>td.warning,.table>thead>tr>th.warning,.table>tbody>tr>th.warning,.table>tfoot>tr>th.warning,.table>thead>tr.warning>td,.table>tbody>tr.warning>td,.table>tfoot>tr.warning>td,.table>thead>tr.warning>th,.table>tbody>tr.warning>th,.table>tfoot>tr.warning>th{background-color:#fcf8e3;border-color:#fbeed5}.table-hover>tbody>tr>td.warning:hover,.table-hover>tbody>tr>th.warning:hover,.table-hover>tbody>tr.warning:hover>td{background-color:#faf2cc;border-color:#f8e5be}@media(max-width:768px){.table-responsive{width:100%;margin-bottom:15px;overflow-x:scroll;overflow-y:hidden;border:1px solid #ddd}.table-responsive>.table{margin-bottom:0;background-color:#fff}.table-responsive>.table>thead>tr>th,.table-responsive>.table>tbody>tr>th,.table-responsive>.table>tfoot>tr>th,.table-responsive>.table>thead>tr>td,.table-responsive>.table>tbody>tr>td,.table-responsive>.table>tfoot>tr>td{white-space:nowrap}.table-responsive>.table-bordered{border:0}.table-responsive>.table-bordered>thead>tr>th:first-child,.table-responsive>.table-bordered>tbody>tr>th:first-child,.table-responsive>.table-bordered>tfoot>tr>th:first-child,.table-responsive>.table-bordered>thead>tr>td:first-child,.table-responsive>.table-bordered>tbody>tr>td:first-child,.table-responsive>.table-bordered>tfoot>tr>td:first-child{border-left:0}.table-responsive>.table-bordered>thead>tr>th:last-child,.table-responsive>.table-bordered>tbody>tr>th:last-child,.table-responsive>.table-bordered>tfoot>tr>th:last-child,.table-responsive>.table-bordered>thead>tr>td:last-child,.table-responsive>.table-bordered>tbody>tr>td:last-child,.table-responsive>.table-bordered>tfoot>tr>td:last-child{border-right:0}.table-responsive>.table-bordered>thead>tr:last-child>th,.table-responsive>.table-bordered>tbody>tr:last-child>th,.table-responsive>.table-bordered>tfoot>tr:last-child>th,.table-responsive>.table-bordered>thead>tr:last-child>td,.table-responsive>.table-bordered>tbody>tr:last-child>td,.table-responsive>.table-bordered>tfoot>tr:last-child>td{border-bottom:0}}fieldset{padding:0;margin:0;border:0}legend{display:block;width:100%;padding:0;margin-bottom:20px;font-size:21px;line-height:inherit;color:#333;border:0;border-bottom:1px solid #e5e5e5}label{display:inline-block;margin-bottom:5px;font-weight:bold}input[type="search"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}input[type="radio"],input[type="checkbox"]{margin:4px 0 0;margin-top:1px \9;line-height:normal}input[type="file"]{display:block}select[multiple],select[size]{height:auto}select optgroup{font-family:inherit;font-size:inherit;font-style:inherit}input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}input[type="number"]::-webkit-outer-spin-button,input[type="number"]::-webkit-inner-spin-button{height:auto}.form-control:-moz-placeholder{color:#999}.form-control::-moz-placeholder{color:#999}.form-control:-ms-input-placeholder{color:#999}.form-control::-webkit-input-placeholder{color:#999}.form-control{display:block;width:100%;height:34px;padding:6px 12px;font-size:14px;line-height:1.428571429;color:#555;vertical-align:middle;background-color:#fff;border:1px solid #ccc;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}.form-control:focus{border-color:#66afe9;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6)}.form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control{cursor:not-allowed;background-color:#eee}textarea.form-control{height:auto}.form-group{margin-bottom:15px}.radio,.checkbox{display:block;min-height:20px;padding-left:20px;margin-top:10px;margin-bottom:10px;vertical-align:middle}.radio label,.checkbox label{display:inline;margin-bottom:0;font-weight:normal;cursor:pointer}.radio input[type="radio"],.radio-inline input[type="radio"],.checkbox input[type="checkbox"],.checkbox-inline input[type="checkbox"]{float:left;margin-left:-20px}.radio+.radio,.checkbox+.checkbox{margin-top:-5px}.radio-inline,.checkbox-inline{display:inline-block;padding-left:20px;margin-bottom:0;font-weight:normal;vertical-align:middle;cursor:pointer}.radio-inline+.radio-inline,.checkbox-inline+.checkbox-inline{margin-top:0;margin-left:10px}input[type="radio"][disabled],input[type="checkbox"][disabled],.radio[disabled],.radio-inline[disabled],.checkbox[disabled],.checkbox-inline[disabled],fieldset[disabled] input[type="radio"],fieldset[disabled] input[type="checkbox"],fieldset[disabled] .radio,fieldset[disabled] .radio-inline,fieldset[disabled] .checkbox,fieldset[disabled] .checkbox-inline{cursor:not-allowed}.input-sm{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-sm{height:30px;line-height:30px}textarea.input-sm{height:auto}.input-lg{height:45px;padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}select.input-lg{height:45px;line-height:45px}textarea.input-lg{height:auto}.has-warning .help-block,.has-warning .control-label{color:#c09853}.has-warning .form-control{border-color:#c09853;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-warning .form-control:focus{border-color:#a47e3c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e}.has-warning .input-group-addon{color:#c09853;background-color:#fcf8e3;border-color:#c09853}.has-error .help-block,.has-error .control-label{color:#b94a48}.has-error .form-control{border-color:#b94a48;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-error .form-control:focus{border-color:#953b39;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392}.has-error .input-group-addon{color:#b94a48;background-color:#f2dede;border-color:#b94a48}.has-success .help-block,.has-success .control-label{color:#468847}.has-success .form-control{border-color:#468847;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-success .form-control:focus{border-color:#356635;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b}.has-success .input-group-addon{color:#468847;background-color:#dff0d8;border-color:#468847}.form-control-static{padding-top:7px;margin-bottom:0}.help-block{display:block;margin-top:5px;margin-bottom:10px;color:#737373}@media(min-width:768px){.form-inline .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}.form-inline .form-control{display:inline-block}.form-inline .radio,.form-inline .checkbox{display:inline-block;padding-left:0;margin-top:0;margin-bottom:0}.form-inline .radio input[type="radio"],.form-inline .checkbox input[type="checkbox"]{float:none;margin-left:0}}.form-horizontal .control-label,.form-horizontal .radio,.form-horizontal .checkbox,.form-horizontal .radio-inline,.form-horizontal .checkbox-inline{padding-top:7px;margin-top:0;margin-bottom:0}.form-horizontal .form-group{margin-right:-15px;margin-left:-15px}.form-horizontal .form-group:before,.form-horizontal .form-group:after{display:table;content:" "}.form-horizontal .form-group:after{clear:both}.form-horizontal .form-group:before,.form-horizontal .form-group:after{display:table;content:" "}.form-horizontal .form-group:after{clear:both}@media(min-width:768px){.form-horizontal .control-label{text-align:right}}.btn{display:inline-block;padding:6px 12px;margin-bottom:0;font-size:14px;font-weight:normal;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;border:1px solid transparent;border-radius:4px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.btn:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}.btn:hover,.btn:focus{color:#333;text-decoration:none}.btn:active,.btn.active{background-image:none;outline:0;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn.disabled,.btn[disabled],fieldset[disabled] .btn{pointer-events:none;cursor:not-allowed;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;box-shadow:none}.btn-default{color:#333;background-color:#fff;border-color:#ccc}.btn-default:hover,.btn-default:focus,.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{color:#333;background-color:#ebebeb;border-color:#adadad}.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{background-image:none}.btn-default.disabled,.btn-default[disabled],fieldset[disabled] .btn-default,.btn-default.disabled:hover,.btn-default[disabled]:hover,fieldset[disabled] .btn-default:hover,.btn-default.disabled:focus,.btn-default[disabled]:focus,fieldset[disabled] .btn-default:focus,.btn-default.disabled:active,.btn-default[disabled]:active,fieldset[disabled] .btn-default:active,.btn-default.disabled.active,.btn-default[disabled].active,fieldset[disabled] .btn-default.active{background-color:#fff;border-color:#ccc}.btn-primary{color:#fff;background-color:#428bca;border-color:#357ebd}.btn-primary:hover,.btn-primary:focus,.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{color:#fff;background-color:#3276b1;border-color:#285e8e}.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{background-image:none}.btn-primary.disabled,.btn-primary[disabled],fieldset[disabled] .btn-primary,.btn-primary.disabled:hover,.btn-primary[disabled]:hover,fieldset[disabled] .btn-primary:hover,.btn-primary.disabled:focus,.btn-primary[disabled]:focus,fieldset[disabled] .btn-primary:focus,.btn-primary.disabled:active,.btn-primary[disabled]:active,fieldset[disabled] .btn-primary:active,.btn-primary.disabled.active,.btn-primary[disabled].active,fieldset[disabled] .btn-primary.active{background-color:#428bca;border-color:#357ebd}.btn-warning{color:#fff;background-color:#f0ad4e;border-color:#eea236}.btn-warning:hover,.btn-warning:focus,.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{color:#fff;background-color:#ed9c28;border-color:#d58512}.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{background-image:none}.btn-warning.disabled,.btn-warning[disabled],fieldset[disabled] .btn-warning,.btn-warning.disabled:hover,.btn-warning[disabled]:hover,fieldset[disabled] .btn-warning:hover,.btn-warning.disabled:focus,.btn-warning[disabled]:focus,fieldset[disabled] .btn-warning:focus,.btn-warning.disabled:active,.btn-warning[disabled]:active,fieldset[disabled] .btn-warning:active,.btn-warning.disabled.active,.btn-warning[disabled].active,fieldset[disabled] .btn-warning.active{background-color:#f0ad4e;border-color:#eea236}.btn-danger{color:#fff;background-color:#d9534f;border-color:#d43f3a}.btn-danger:hover,.btn-danger:focus,.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{color:#fff;background-color:#d2322d;border-color:#ac2925}.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{background-image:none}.btn-danger.disabled,.btn-danger[disabled],fieldset[disabled] .btn-danger,.btn-danger.disabled:hover,.btn-danger[disabled]:hover,fieldset[disabled] .btn-danger:hover,.btn-danger.disabled:focus,.btn-danger[disabled]:focus,fieldset[disabled] .btn-danger:focus,.btn-danger.disabled:active,.btn-danger[disabled]:active,fieldset[disabled] .btn-danger:active,.btn-danger.disabled.active,.btn-danger[disabled].active,fieldset[disabled] .btn-danger.active{background-color:#d9534f;border-color:#d43f3a}.btn-success{color:#fff;background-color:#5cb85c;border-color:#4cae4c}.btn-success:hover,.btn-success:focus,.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{color:#fff;background-color:#47a447;border-color:#398439}.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{background-image:none}.btn-success.disabled,.btn-success[disabled],fieldset[disabled] .btn-success,.btn-success.disabled:hover,.btn-success[disabled]:hover,fieldset[disabled] .btn-success:hover,.btn-success.disabled:focus,.btn-success[disabled]:focus,fieldset[disabled] .btn-success:focus,.btn-success.disabled:active,.btn-success[disabled]:active,fieldset[disabled] .btn-success:active,.btn-success.disabled.active,.btn-success[disabled].active,fieldset[disabled] .btn-success.active{background-color:#5cb85c;border-color:#4cae4c}.btn-info{color:#fff;background-color:#5bc0de;border-color:#46b8da}.btn-info:hover,.btn-info:focus,.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{color:#fff;background-color:#39b3d7;border-color:#269abc}.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{background-image:none}.btn-info.disabled,.btn-info[disabled],fieldset[disabled] .btn-info,.btn-info.disabled:hover,.btn-info[disabled]:hover,fieldset[disabled] .btn-info:hover,.btn-info.disabled:focus,.btn-info[disabled]:focus,fieldset[disabled] .btn-info:focus,.btn-info.disabled:active,.btn-info[disabled]:active,fieldset[disabled] .btn-info:active,.btn-info.disabled.active,.btn-info[disabled].active,fieldset[disabled] .btn-info.active{background-color:#5bc0de;border-color:#46b8da}.btn-link{font-weight:normal;color:#428bca;cursor:pointer;border-radius:0}.btn-link,.btn-link:active,.btn-link[disabled],fieldset[disabled] .btn-link{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}.btn-link,.btn-link:hover,.btn-link:focus,.btn-link:active{border-color:transparent}.btn-link:hover,.btn-link:focus{color:#2a6496;text-decoration:underline;background-color:transparent}.btn-link[disabled]:hover,fieldset[disabled] .btn-link:hover,.btn-link[disabled]:focus,fieldset[disabled] .btn-link:focus{color:#999;text-decoration:none}.btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}.btn-sm,.btn-xs{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}.btn-xs{padding:1px 5px}.btn-block{display:block;width:100%;padding-right:0;padding-left:0}.btn-block+.btn-block{margin-top:5px}input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"].btn-block{width:100%}.fade{opacity:0;-webkit-transition:opacity .15s linear;transition:opacity .15s linear}.fade.in{opacity:1}.collapse{display:none}.collapse.in{display:block}.collapsing{position:relative;height:0;overflow:hidden;-webkit-transition:height .35s ease;transition:height .35s ease}@font-face{font-family:'Glyphicons Halflings';src:url('../fonts/glyphicons-halflings-regular.eot');src:url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'),url('../fonts/glyphicons-halflings-regular.woff') format('woff'),url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'),url('../fonts/glyphicons-halflings-regular.svg#glyphicons-halflingsregular') format('svg')}.glyphicon{position:relative;top:1px;display:inline-block;font-family:'Glyphicons Halflings';-webkit-font-smoothing:antialiased;font-style:normal;font-weight:normal;line-height:1}.glyphicon-asterisk:before{content:"\2a"}.glyphicon-plus:before{content:"\2b"}.glyphicon-euro:before{content:"\20ac"}.glyphicon-minus:before{content:"\2212"}.glyphicon-cloud:before{content:"\2601"}.glyphicon-envelope:before{content:"\2709"}.glyphicon-pencil:before{content:"\270f"}.glyphicon-glass:before{content:"\e001"}.glyphicon-music:before{content:"\e002"}.glyphicon-search:before{content:"\e003"}.glyphicon-heart:before{content:"\e005"}.glyphicon-star:before{content:"\e006"}.glyphicon-star-empty:before{content:"\e007"}.glyphicon-user:before{content:"\e008"}.glyphicon-film:before{content:"\e009"}.glyphicon-th-large:before{content:"\e010"}.glyphicon-th:before{content:"\e011"}.glyphicon-th-list:before{content:"\e012"}.glyphicon-ok:before{content:"\e013"}.glyphicon-remove:before{content:"\e014"}.glyphicon-zoom-in:before{content:"\e015"}.glyphicon-zoom-out:before{content:"\e016"}.glyphicon-off:before{content:"\e017"}.glyphicon-signal:before{content:"\e018"}.glyphicon-cog:before{content:"\e019"}.glyphicon-trash:before{content:"\e020"}.glyphicon-home:before{content:"\e021"}.glyphicon-file:before{content:"\e022"}.glyphicon-time:before{content:"\e023"}.glyphicon-road:before{content:"\e024"}.glyphicon-download-alt:before{content:"\e025"}.glyphicon-download:before{content:"\e026"}.glyphicon-upload:before{content:"\e027"}.glyphicon-inbox:before{content:"\e028"}.glyphicon-play-circle:before{content:"\e029"}.glyphicon-repeat:before{content:"\e030"}.glyphicon-refresh:before{content:"\e031"}.glyphicon-list-alt:before{content:"\e032"}.glyphicon-flag:before{content:"\e034"}.glyphicon-headphones:before{content:"\e035"}.glyphicon-volume-off:before{content:"\e036"}.glyphicon-volume-down:before{content:"\e037"}.glyphicon-volume-up:before{content:"\e038"}.glyphicon-qrcode:before{content:"\e039"}.glyphicon-barcode:before{content:"\e040"}.glyphicon-tag:before{content:"\e041"}.glyphicon-tags:before{content:"\e042"}.glyphicon-book:before{content:"\e043"}.glyphicon-print:before{content:"\e045"}.glyphicon-font:before{content:"\e047"}.glyphicon-bold:before{content:"\e048"}.glyphicon-italic:before{content:"\e049"}.glyphicon-text-height:before{content:"\e050"}.glyphicon-text-width:before{content:"\e051"}.glyphicon-align-left:before{content:"\e052"}.glyphicon-align-center:before{content:"\e053"}.glyphicon-align-right:before{content:"\e054"}.glyphicon-align-justify:before{content:"\e055"}.glyphicon-list:before{content:"\e056"}.glyphicon-indent-left:before{content:"\e057"}.glyphicon-indent-right:before{content:"\e058"}.glyphicon-facetime-video:before{content:"\e059"}.glyphicon-picture:before{content:"\e060"}.glyphicon-map-marker:before{content:"\e062"}.glyphicon-adjust:before{content:"\e063"}.glyphicon-tint:before{content:"\e064"}.glyphicon-edit:before{content:"\e065"}.glyphicon-share:before{content:"\e066"}.glyphicon-check:before{content:"\e067"}.glyphicon-move:before{content:"\e068"}.glyphicon-step-backward:before{content:"\e069"}.glyphicon-fast-backward:before{content:"\e070"}.glyphicon-backward:before{content:"\e071"}.glyphicon-play:before{content:"\e072"}.glyphicon-pause:before{content:"\e073"}.glyphicon-stop:before{content:"\e074"}.glyphicon-forward:before{content:"\e075"}.glyphicon-fast-forward:before{content:"\e076"}.glyphicon-step-forward:before{content:"\e077"}.glyphicon-eject:before{content:"\e078"}.glyphicon-chevron-left:before{content:"\e079"}.glyphicon-chevron-right:before{content:"\e080"}.glyphicon-plus-sign:before{content:"\e081"}.glyphicon-minus-sign:before{content:"\e082"}.glyphicon-remove-sign:before{content:"\e083"}.glyphicon-ok-sign:before{content:"\e084"}.glyphicon-question-sign:before{content:"\e085"}.glyphicon-info-sign:before{content:"\e086"}.glyphicon-screenshot:before{content:"\e087"}.glyphicon-remove-circle:before{content:"\e088"}.glyphicon-ok-circle:before{content:"\e089"}.glyphicon-ban-circle:before{content:"\e090"}.glyphicon-arrow-left:before{content:"\e091"}.glyphicon-arrow-right:before{content:"\e092"}.glyphicon-arrow-up:before{content:"\e093"}.glyphicon-arrow-down:before{content:"\e094"}.glyphicon-share-alt:before{content:"\e095"}.glyphicon-resize-full:before{content:"\e096"}.glyphicon-resize-small:before{content:"\e097"}.glyphicon-exclamation-sign:before{content:"\e101"}.glyphicon-gift:before{content:"\e102"}.glyphicon-leaf:before{content:"\e103"}.glyphicon-eye-open:before{content:"\e105"}.glyphicon-eye-close:before{content:"\e106"}.glyphicon-warning-sign:before{content:"\e107"}.glyphicon-plane:before{content:"\e108"}.glyphicon-random:before{content:"\e110"}.glyphicon-comment:before{content:"\e111"}.glyphicon-magnet:before{content:"\e112"}.glyphicon-chevron-up:before{content:"\e113"}.glyphicon-chevron-down:before{content:"\e114"}.glyphicon-retweet:before{content:"\e115"}.glyphicon-shopping-cart:before{content:"\e116"}.glyphicon-folder-close:before{content:"\e117"}.glyphicon-folder-open:before{content:"\e118"}.glyphicon-resize-vertical:before{content:"\e119"}.glyphicon-resize-horizontal:before{content:"\e120"}.glyphicon-hdd:before{content:"\e121"}.glyphicon-bullhorn:before{content:"\e122"}.glyphicon-certificate:before{content:"\e124"}.glyphicon-thumbs-up:before{content:"\e125"}.glyphicon-thumbs-down:before{content:"\e126"}.glyphicon-hand-right:before{content:"\e127"}.glyphicon-hand-left:before{content:"\e128"}.glyphicon-hand-up:before{content:"\e129"}.glyphicon-hand-down:before{content:"\e130"}.glyphicon-circle-arrow-right:before{content:"\e131"}.glyphicon-circle-arrow-left:before{content:"\e132"}.glyphicon-circle-arrow-up:before{content:"\e133"}.glyphicon-circle-arrow-down:before{content:"\e134"}.glyphicon-globe:before{content:"\e135"}.glyphicon-tasks:before{content:"\e137"}.glyphicon-filter:before{content:"\e138"}.glyphicon-fullscreen:before{content:"\e140"}.glyphicon-dashboard:before{content:"\e141"}.glyphicon-heart-empty:before{content:"\e143"}.glyphicon-link:before{content:"\e144"}.glyphicon-phone:before{content:"\e145"}.glyphicon-usd:before{content:"\e148"}.glyphicon-gbp:before{content:"\e149"}.glyphicon-sort:before{content:"\e150"}.glyphicon-sort-by-alphabet:before{content:"\e151"}.glyphicon-sort-by-alphabet-alt:before{content:"\e152"}.glyphicon-sort-by-order:before{content:"\e153"}.glyphicon-sort-by-order-alt:before{content:"\e154"}.glyphicon-sort-by-attributes:before{content:"\e155"}.glyphicon-sort-by-attributes-alt:before{content:"\e156"}.glyphicon-unchecked:before{content:"\e157"}.glyphicon-expand:before{content:"\e158"}.glyphicon-collapse-down:before{content:"\e159"}.glyphicon-collapse-up:before{content:"\e160"}.glyphicon-log-in:before{content:"\e161"}.glyphicon-flash:before{content:"\e162"}.glyphicon-log-out:before{content:"\e163"}.glyphicon-new-window:before{content:"\e164"}.glyphicon-record:before{content:"\e165"}.glyphicon-save:before{content:"\e166"}.glyphicon-open:before{content:"\e167"}.glyphicon-saved:before{content:"\e168"}.glyphicon-import:before{content:"\e169"}.glyphicon-export:before{content:"\e170"}.glyphicon-send:before{content:"\e171"}.glyphicon-floppy-disk:before{content:"\e172"}.glyphicon-floppy-saved:before{content:"\e173"}.glyphicon-floppy-remove:before{content:"\e174"}.glyphicon-floppy-save:before{content:"\e175"}.glyphicon-floppy-open:before{content:"\e176"}.glyphicon-credit-card:before{content:"\e177"}.glyphicon-transfer:before{content:"\e178"}.glyphicon-cutlery:before{content:"\e179"}.glyphicon-header:before{content:"\e180"}.glyphicon-compressed:before{content:"\e181"}.glyphicon-earphone:before{content:"\e182"}.glyphicon-phone-alt:before{content:"\e183"}.glyphicon-tower:before{content:"\e184"}.glyphicon-stats:before{content:"\e185"}.glyphicon-sd-video:before{content:"\e186"}.glyphicon-hd-video:before{content:"\e187"}.glyphicon-subtitles:before{content:"\e188"}.glyphicon-sound-stereo:before{content:"\e189"}.glyphicon-sound-dolby:before{content:"\e190"}.glyphicon-sound-5-1:before{content:"\e191"}.glyphicon-sound-6-1:before{content:"\e192"}.glyphicon-sound-7-1:before{content:"\e193"}.glyphicon-copyright-mark:before{content:"\e194"}.glyphicon-registration-mark:before{content:"\e195"}.glyphicon-cloud-download:before{content:"\e197"}.glyphicon-cloud-upload:before{content:"\e198"}.glyphicon-tree-conifer:before{content:"\e199"}.glyphicon-tree-deciduous:before{content:"\e200"}.glyphicon-briefcase:before{content:"\1f4bc"}.glyphicon-calendar:before{content:"\1f4c5"}.glyphicon-pushpin:before{content:"\1f4cc"}.glyphicon-paperclip:before{content:"\1f4ce"}.glyphicon-camera:before{content:"\1f4f7"}.glyphicon-lock:before{content:"\1f512"}.glyphicon-bell:before{content:"\1f514"}.glyphicon-bookmark:before{content:"\1f516"}.glyphicon-fire:before{content:"\1f525"}.glyphicon-wrench:before{content:"\1f527"}.caret{display:inline-block;width:0;height:0;margin-left:2px;vertical-align:middle;border-top:4px solid #000;border-right:4px solid transparent;border-bottom:0 dotted;border-left:4px solid transparent;content:""}.dropdown{position:relative}.dropdown-toggle:focus{outline:0}.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;font-size:14px;list-style:none;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.15);border-radius:4px;-webkit-box-shadow:0 6px 12px rgba(0,0,0,0.175);box-shadow:0 6px 12px rgba(0,0,0,0.175);background-clip:padding-box}.dropdown-menu.pull-right{right:0;left:auto}.dropdown-menu .divider{height:1px;margin:9px 0;overflow:hidden;background-color:#e5e5e5}.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:normal;line-height:1.428571429;color:#333;white-space:nowrap}.dropdown-menu>li>a:hover,.dropdown-menu>li>a:focus{color:#fff;text-decoration:none;background-color:#428bca}.dropdown-menu>.active>a,.dropdown-menu>.active>a:hover,.dropdown-menu>.active>a:focus{color:#fff;text-decoration:none;background-color:#428bca;outline:0}.dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{color:#999}.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{text-decoration:none;cursor:not-allowed;background-color:transparent;background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.open>.dropdown-menu{display:block}.open>a{outline:0}.dropdown-header{display:block;padding:3px 20px;font-size:12px;line-height:1.428571429;color:#999}.dropdown-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:990}.pull-right>.dropdown-menu{right:0;left:auto}.dropup .caret,.navbar-fixed-bottom .dropdown .caret{border-top:0 dotted;border-bottom:4px solid #000;content:""}.dropup .dropdown-menu,.navbar-fixed-bottom .dropdown .dropdown-menu{top:auto;bottom:100%;margin-bottom:1px}@media(min-width:768px){.navbar-right .dropdown-menu{right:0;left:auto}}.btn-default .caret{border-top-color:#333}.btn-primary .caret,.btn-success .caret,.btn-warning .caret,.btn-danger .caret,.btn-info .caret{border-top-color:#fff}.dropup .btn-default .caret{border-bottom-color:#333}.dropup .btn-primary .caret,.dropup .btn-success .caret,.dropup .btn-warning .caret,.dropup .btn-danger .caret,.dropup .btn-info .caret{border-bottom-color:#fff}.btn-group,.btn-group-vertical{position:relative;display:inline-block;vertical-align:middle}.btn-group>.btn,.btn-group-vertical>.btn{position:relative;float:left}.btn-group>.btn:hover,.btn-group-vertical>.btn:hover,.btn-group>.btn:focus,.btn-group-vertical>.btn:focus,.btn-group>.btn:active,.btn-group-vertical>.btn:active,.btn-group>.btn.active,.btn-group-vertical>.btn.active{z-index:2}.btn-group>.btn:focus,.btn-group-vertical>.btn:focus{outline:0}.btn-group .btn+.btn,.btn-group .btn+.btn-group,.btn-group .btn-group+.btn,.btn-group .btn-group+.btn-group{margin-left:-1px}.btn-toolbar:before,.btn-toolbar:after{display:table;content:" "}.btn-toolbar:after{clear:both}.btn-toolbar:before,.btn-toolbar:after{display:table;content:" "}.btn-toolbar:after{clear:both}.btn-toolbar .btn-group{float:left}.btn-toolbar>.btn+.btn,.btn-toolbar>.btn-group+.btn,.btn-toolbar>.btn+.btn-group,.btn-toolbar>.btn-group+.btn-group{margin-left:5px}.btn-group>.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}.btn-group>.btn:first-child{margin-left:0}.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle){border-top-right-radius:0;border-bottom-right-radius:0}.btn-group>.btn:last-child:not(:first-child),.btn-group>.dropdown-toggle:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}.btn-group>.btn-group{float:left}.btn-group>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}.btn-group>.btn-group:first-child>.btn:last-child,.btn-group>.btn-group:first-child>.dropdown-toggle{border-top-right-radius:0;border-bottom-right-radius:0}.btn-group>.btn-group:last-child>.btn:first-child{border-bottom-left-radius:0;border-top-left-radius:0}.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}.btn-group-xs>.btn{padding:5px 10px;padding:1px 5px;font-size:12px;line-height:1.5;border-radius:3px}.btn-group-sm>.btn{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}.btn-group-lg>.btn{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}.btn-group>.btn+.dropdown-toggle{padding-right:8px;padding-left:8px}.btn-group>.btn-lg+.dropdown-toggle{padding-right:12px;padding-left:12px}.btn-group.open .dropdown-toggle{-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn .caret{margin-left:0}.btn-lg .caret{border-width:5px 5px 0;border-bottom-width:0}.dropup .btn-lg .caret{border-width:0 5px 5px}.btn-group-vertical>.btn,.btn-group-vertical>.btn-group{display:block;float:none;width:100%;max-width:100%}.btn-group-vertical>.btn-group:before,.btn-group-vertical>.btn-group:after{display:table;content:" "}.btn-group-vertical>.btn-group:after{clear:both}.btn-group-vertical>.btn-group:before,.btn-group-vertical>.btn-group:after{display:table;content:" "}.btn-group-vertical>.btn-group:after{clear:both}.btn-group-vertical>.btn-group>.btn{float:none}.btn-group-vertical>.btn+.btn,.btn-group-vertical>.btn+.btn-group,.btn-group-vertical>.btn-group+.btn,.btn-group-vertical>.btn-group+.btn-group{margin-top:-1px;margin-left:0}.btn-group-vertical>.btn:not(:first-child):not(:last-child){border-radius:0}.btn-group-vertical>.btn:first-child:not(:last-child){border-top-right-radius:4px;border-bottom-right-radius:0;border-bottom-left-radius:0}.btn-group-vertical>.btn:last-child:not(:first-child){border-top-right-radius:0;border-bottom-left-radius:4px;border-top-left-radius:0}.btn-group-vertical>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}.btn-group-vertical>.btn-group:first-child>.btn:last-child,.btn-group-vertical>.btn-group:first-child>.dropdown-toggle{border-bottom-right-radius:0;border-bottom-left-radius:0}.btn-group-vertical>.btn-group:last-child>.btn:first-child{border-top-right-radius:0;border-top-left-radius:0}.btn-group-justified{display:table;width:100%;border-collapse:separate;table-layout:fixed}.btn-group-justified .btn{display:table-cell;float:none;width:1%}[data-toggle="buttons"]>.btn>input[type="radio"],[data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}.input-group{position:relative;display:table;border-collapse:separate}.input-group.col{float:none;padding-right:0;padding-left:0}.input-group .form-control{width:100%;margin-bottom:0}.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:45px;padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:45px;line-height:45px}textarea.input-group-lg>.form-control,textarea.input-group-lg>.input-group-addon,textarea.input-group-lg>.input-group-btn>.btn{height:auto}.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:30px;line-height:30px}textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon,textarea.input-group-sm>.input-group-btn>.btn{height:auto}.input-group-addon,.input-group-btn,.input-group .form-control{display:table-cell}.input-group-addon:not(:first-child):not(:last-child),.input-group-btn:not(:first-child):not(:last-child),.input-group .form-control:not(:first-child):not(:last-child){border-radius:0}.input-group-addon,.input-group-btn{width:1%;white-space:nowrap;vertical-align:middle}.input-group-addon{padding:6px 12px;font-size:14px;font-weight:normal;line-height:1;text-align:center;background-color:#eee;border:1px solid #ccc;border-radius:4px}.input-group-addon.input-sm{padding:5px 10px;font-size:12px;border-radius:3px}.input-group-addon.input-lg{padding:10px 16px;font-size:18px;border-radius:6px}.input-group-addon input[type="radio"],.input-group-addon input[type="checkbox"]{margin-top:0}.input-group .form-control:first-child,.input-group-addon:first-child,.input-group-btn:first-child>.btn,.input-group-btn:first-child>.dropdown-toggle,.input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle){border-top-right-radius:0;border-bottom-right-radius:0}.input-group-addon:first-child{border-right:0}.input-group .form-control:last-child,.input-group-addon:last-child,.input-group-btn:last-child>.btn,.input-group-btn:last-child>.dropdown-toggle,.input-group-btn:first-child>.btn:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}.input-group-addon:last-child{border-left:0}.input-group-btn{position:relative;white-space:nowrap}.input-group-btn>.btn{position:relative}.input-group-btn>.btn+.btn{margin-left:-4px}.input-group-btn>.btn:hover,.input-group-btn>.btn:active{z-index:2}.nav{padding-left:0;margin-bottom:0;list-style:none}.nav:before,.nav:after{display:table;content:" "}.nav:after{clear:both}.nav:before,.nav:after{display:table;content:" "}.nav:after{clear:both}.nav>li{position:relative;display:block}.nav>li>a{position:relative;display:block;padding:10px 15px}.nav>li>a:hover,.nav>li>a:focus{text-decoration:none;background-color:#eee}.nav>li.disabled>a{color:#999}.nav>li.disabled>a:hover,.nav>li.disabled>a:focus{color:#999;text-decoration:none;cursor:not-allowed;background-color:transparent}.nav .open>a,.nav .open>a:hover,.nav .open>a:focus{background-color:#eee;border-color:#428bca}.nav .nav-divider{height:1px;margin:9px 0;overflow:hidden;background-color:#e5e5e5}.nav>li>a>img{max-width:none}.nav-tabs{border-bottom:1px solid #ddd}.nav-tabs>li{float:left;margin-bottom:-1px}.nav-tabs>li>a{margin-right:2px;line-height:1.428571429;border:1px solid transparent;border-radius:4px 4px 0 0}.nav-tabs>li>a:hover{border-color:#eee #eee #ddd}.nav-tabs>li.active>a,.nav-tabs>li.active>a:hover,.nav-tabs>li.active>a:focus{color:#555;cursor:default;background-color:#fff;border:1px solid #ddd;border-bottom-color:transparent}.nav-tabs.nav-justified{width:100%;border-bottom:0}.nav-tabs.nav-justified>li{float:none}.nav-tabs.nav-justified>li>a{text-align:center}@media(min-width:768px){.nav-tabs.nav-justified>li{display:table-cell;width:1%}}.nav-tabs.nav-justified>li>a{margin-right:0;border-bottom:1px solid #ddd}.nav-tabs.nav-justified>.active>a{border-bottom-color:#fff}.nav-pills>li{float:left}.nav-pills>li>a{border-radius:5px}.nav-pills>li+li{margin-left:2px}.nav-pills>li.active>a,.nav-pills>li.active>a:hover,.nav-pills>li.active>a:focus{color:#fff;background-color:#428bca}.nav-stacked>li{float:none}.nav-stacked>li+li{margin-top:2px;margin-left:0}.nav-justified{width:100%}.nav-justified>li{float:none}.nav-justified>li>a{text-align:center}@media(min-width:768px){.nav-justified>li{display:table-cell;width:1%}}.nav-tabs-justified{border-bottom:0}.nav-tabs-justified>li>a{margin-right:0;border-bottom:1px solid #ddd}.nav-tabs-justified>.active>a{border-bottom-color:#fff}.tabbable:before,.tabbable:after{display:table;content:" "}.tabbable:after{clear:both}.tabbable:before,.tabbable:after{display:table;content:" "}.tabbable:after{clear:both}.tab-content>.tab-pane,.pill-content>.pill-pane{display:none}.tab-content>.active,.pill-content>.active{display:block}.nav .caret{border-top-color:#428bca;border-bottom-color:#428bca}.nav a:hover .caret{border-top-color:#2a6496;border-bottom-color:#2a6496}.nav-tabs .dropdown-menu{margin-top:-1px;border-top-right-radius:0;border-top-left-radius:0}.navbar{position:relative;z-index:1000;min-height:50px;margin-bottom:20px;border:1px solid transparent}.navbar:before,.navbar:after{display:table;content:" "}.navbar:after{clear:both}.navbar:before,.navbar:after{display:table;content:" "}.navbar:after{clear:both}@media(min-width:768px){.navbar{border-radius:4px}}.navbar-header:before,.navbar-header:after{display:table;content:" "}.navbar-header:after{clear:both}.navbar-header:before,.navbar-header:after{display:table;content:" "}.navbar-header:after{clear:both}@media(min-width:768px){.navbar-header{float:left}}.navbar-collapse{max-height:340px;padding-right:15px;padding-left:15px;overflow-x:visible;border-top:1px solid transparent;box-shadow:inset 0 1px 0 rgba(255,255,255,0.1);-webkit-overflow-scrolling:touch}.navbar-collapse:before,.navbar-collapse:after{display:table;content:" "}.navbar-collapse:after{clear:both}.navbar-collapse:before,.navbar-collapse:after{display:table;content:" "}.navbar-collapse:after{clear:both}.navbar-collapse.in{overflow-y:auto}@media(min-width:768px){.navbar-collapse{width:auto;border-top:0;box-shadow:none}.navbar-collapse.collapse{display:block!important;height:auto!important;padding-bottom:0;overflow:visible!important}.navbar-collapse.in{overflow-y:visible}.navbar-collapse .navbar-nav.navbar-left:first-child{margin-left:-15px}.navbar-collapse .navbar-nav.navbar-right:last-child{margin-right:-15px}.navbar-collapse .navbar-text:last-child{margin-right:0}}.container>.navbar-header,.container>.navbar-collapse{margin-right:-15px;margin-left:-15px}@media(min-width:768px){.container>.navbar-header,.container>.navbar-collapse{margin-right:0;margin-left:0}}.navbar-static-top{border-width:0 0 1px}@media(min-width:768px){.navbar-static-top{border-radius:0}}.navbar-fixed-top,.navbar-fixed-bottom{position:fixed;right:0;left:0;border-width:0 0 1px}@media(min-width:768px){.navbar-fixed-top,.navbar-fixed-bottom{border-radius:0}}.navbar-fixed-top{top:0;z-index:1030}.navbar-fixed-bottom{bottom:0;margin-bottom:0}.navbar-brand{float:left;padding:15px 15px;font-size:18px;line-height:20px}.navbar-brand:hover,.navbar-brand:focus{text-decoration:none}@media(min-width:768px){.navbar>.container .navbar-brand{margin-left:-15px}}.navbar-toggle{position:relative;float:right;padding:9px 10px;margin-top:8px;margin-right:15px;margin-bottom:8px;background-color:transparent;border:1px solid transparent;border-radius:4px}.navbar-toggle .icon-bar{display:block;width:22px;height:2px;border-radius:1px}.navbar-toggle .icon-bar+.icon-bar{margin-top:4px}@media(min-width:768px){.navbar-toggle{display:none}}.navbar-nav{margin:7.5px -15px}.navbar-nav>li>a{padding-top:10px;padding-bottom:10px;line-height:20px}@media(max-width:767px){.navbar-nav .open .dropdown-menu{position:static;float:none;width:auto;margin-top:0;background-color:transparent;border:0;box-shadow:none}.navbar-nav .open .dropdown-menu>li>a,.navbar-nav .open .dropdown-menu .dropdown-header{padding:5px 15px 5px 25px}.navbar-nav .open .dropdown-menu>li>a{line-height:20px}.navbar-nav .open .dropdown-menu>li>a:hover,.navbar-nav .open .dropdown-menu>li>a:focus{background-image:none}}@media(min-width:768px){.navbar-nav{float:left;margin:0}.navbar-nav>li{float:left}.navbar-nav>li>a{padding-top:15px;padding-bottom:15px}}@media(min-width:768px){.navbar-left{float:left!important}.navbar-right{float:right!important}}.navbar-form{padding:10px 15px;margin-top:8px;margin-right:-15px;margin-bottom:8px;margin-left:-15px;border-top:1px solid transparent;border-bottom:1px solid transparent;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1)}@media(min-width:768px){.navbar-form .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}.navbar-form .form-control{display:inline-block}.navbar-form .radio,.navbar-form .checkbox{display:inline-block;padding-left:0;margin-top:0;margin-bottom:0}.navbar-form .radio input[type="radio"],.navbar-form .checkbox input[type="checkbox"]{float:none;margin-left:0}}@media(max-width:767px){.navbar-form .form-group{margin-bottom:5px}}@media(min-width:768px){.navbar-form{width:auto;padding-top:0;padding-bottom:0;margin-right:0;margin-left:0;border:0;-webkit-box-shadow:none;box-shadow:none}}.navbar-nav>li>.dropdown-menu{margin-top:0;border-top-right-radius:0;border-top-left-radius:0}.navbar-fixed-bottom .navbar-nav>li>.dropdown-menu{border-bottom-right-radius:0;border-bottom-left-radius:0}.navbar-nav.pull-right>li>.dropdown-menu,.navbar-nav>li>.dropdown-menu.pull-right{right:0;left:auto}.navbar-btn{margin-top:8px;margin-bottom:8px}.navbar-text{float:left;margin-top:15px;margin-bottom:15px}@media(min-width:768px){.navbar-text{margin-right:15px;margin-left:15px}}.navbar-default{background-color:#f8f8f8;border-color:#e7e7e7}.navbar-default .navbar-brand{color:#777}.navbar-default .navbar-brand:hover,.navbar-default .navbar-brand:focus{color:#5e5e5e;background-color:transparent}.navbar-default .navbar-text{color:#777}.navbar-default .navbar-nav>li>a{color:#777}.navbar-default .navbar-nav>li>a:hover,.navbar-default .navbar-nav>li>a:focus{color:#333;background-color:transparent}.navbar-default .navbar-nav>.active>a,.navbar-default .navbar-nav>.active>a:hover,.navbar-default .navbar-nav>.active>a:focus{color:#555;background-color:#e7e7e7}.navbar-default .navbar-nav>.disabled>a,.navbar-default .navbar-nav>.disabled>a:hover,.navbar-default .navbar-nav>.disabled>a:focus{color:#ccc;background-color:transparent}.navbar-default .navbar-toggle{border-color:#ddd}.navbar-default .navbar-toggle:hover,.navbar-default .navbar-toggle:focus{background-color:#ddd}.navbar-default .navbar-toggle .icon-bar{background-color:#ccc}.navbar-default .navbar-collapse,.navbar-default .navbar-form{border-color:#e6e6e6}.navbar-default .navbar-nav>.dropdown>a:hover .caret,.navbar-default .navbar-nav>.dropdown>a:focus .caret{border-top-color:#333;border-bottom-color:#333}.navbar-default .navbar-nav>.open>a,.navbar-default .navbar-nav>.open>a:hover,.navbar-default .navbar-nav>.open>a:focus{color:#555;background-color:#e7e7e7}.navbar-default .navbar-nav>.open>a .caret,.navbar-default .navbar-nav>.open>a:hover .caret,.navbar-default .navbar-nav>.open>a:focus .caret{border-top-color:#555;border-bottom-color:#555}.navbar-default .navbar-nav>.dropdown>a .caret{border-top-color:#777;border-bottom-color:#777}@media(max-width:767px){.navbar-default .navbar-nav .open .dropdown-menu>li>a{color:#777}.navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>li>a:focus{color:#333;background-color:transparent}.navbar-default .navbar-nav .open .dropdown-menu>.active>a,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:focus{color:#555;background-color:#e7e7e7}.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#ccc;background-color:transparent}}.navbar-default .navbar-link{color:#777}.navbar-default .navbar-link:hover{color:#333}.navbar-inverse{background-color:#222;border-color:#080808}.navbar-inverse .navbar-brand{color:#999}.navbar-inverse .navbar-brand:hover,.navbar-inverse .navbar-brand:focus{color:#fff;background-color:transparent}.navbar-inverse .navbar-text{color:#999}.navbar-inverse .navbar-nav>li>a{color:#999}.navbar-inverse .navbar-nav>li>a:hover,.navbar-inverse .navbar-nav>li>a:focus{color:#fff;background-color:transparent}.navbar-inverse .navbar-nav>.active>a,.navbar-inverse .navbar-nav>.active>a:hover,.navbar-inverse .navbar-nav>.active>a:focus{color:#fff;background-color:#080808}.navbar-inverse .navbar-nav>.disabled>a,.navbar-inverse .navbar-nav>.disabled>a:hover,.navbar-inverse .navbar-nav>.disabled>a:focus{color:#444;background-color:transparent}.navbar-inverse .navbar-toggle{border-color:#333}.navbar-inverse .navbar-toggle:hover,.navbar-inverse .navbar-toggle:focus{background-color:#333}.navbar-inverse .navbar-toggle .icon-bar{background-color:#fff}.navbar-inverse .navbar-collapse,.navbar-inverse .navbar-form{border-color:#101010}.navbar-inverse .navbar-nav>.open>a,.navbar-inverse .navbar-nav>.open>a:hover,.navbar-inverse .navbar-nav>.open>a:focus{color:#fff;background-color:#080808}.navbar-inverse .navbar-nav>.dropdown>a:hover .caret{border-top-color:#fff;border-bottom-color:#fff}.navbar-inverse .navbar-nav>.dropdown>a .caret{border-top-color:#999;border-bottom-color:#999}.navbar-inverse .navbar-nav>.open>a .caret,.navbar-inverse .navbar-nav>.open>a:hover .caret,.navbar-inverse .navbar-nav>.open>a:focus .caret{border-top-color:#fff;border-bottom-color:#fff}@media(max-width:767px){.navbar-inverse .navbar-nav .open .dropdown-menu>.dropdown-header{border-color:#080808}.navbar-inverse .navbar-nav .open .dropdown-menu>li>a{color:#999}.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:focus{color:#fff;background-color:transparent}.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:focus{color:#fff;background-color:#080808}.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#444;background-color:transparent}}.navbar-inverse .navbar-link{color:#999}.navbar-inverse .navbar-link:hover{color:#fff}.breadcrumb{padding:8px 15px;margin-bottom:20px;list-style:none;background-color:#f5f5f5;border-radius:4px}.breadcrumb>li{display:inline-block}.breadcrumb>li+li:before{padding:0 5px;color:#ccc;content:"/\00a0"}.breadcrumb>.active{color:#999}.pagination{display:inline-block;padding-left:0;margin:20px 0;border-radius:4px}.pagination>li{display:inline}.pagination>li>a,.pagination>li>span{position:relative;float:left;padding:6px 12px;margin-left:-1px;line-height:1.428571429;text-decoration:none;background-color:#fff;border:1px solid #ddd}.pagination>li:first-child>a,.pagination>li:first-child>span{margin-left:0;border-bottom-left-radius:4px;border-top-left-radius:4px}.pagination>li:last-child>a,.pagination>li:last-child>span{border-top-right-radius:4px;border-bottom-right-radius:4px}.pagination>li>a:hover,.pagination>li>span:hover,.pagination>li>a:focus,.pagination>li>span:focus{background-color:#eee}.pagination>.active>a,.pagination>.active>span,.pagination>.active>a:hover,.pagination>.active>span:hover,.pagination>.active>a:focus,.pagination>.active>span:focus{z-index:2;color:#fff;cursor:default;background-color:#428bca;border-color:#428bca}.pagination>.disabled>span,.pagination>.disabled>a,.pagination>.disabled>a:hover,.pagination>.disabled>a:focus{color:#999;cursor:not-allowed;background-color:#fff;border-color:#ddd}.pagination-lg>li>a,.pagination-lg>li>span{padding:10px 16px;font-size:18px}.pagination-lg>li:first-child>a,.pagination-lg>li:first-child>span{border-bottom-left-radius:6px;border-top-left-radius:6px}.pagination-lg>li:last-child>a,.pagination-lg>li:last-child>span{border-top-right-radius:6px;border-bottom-right-radius:6px}.pagination-sm>li>a,.pagination-sm>li>span{padding:5px 10px;font-size:12px}.pagination-sm>li:first-child>a,.pagination-sm>li:first-child>span{border-bottom-left-radius:3px;border-top-left-radius:3px}.pagination-sm>li:last-child>a,.pagination-sm>li:last-child>span{border-top-right-radius:3px;border-bottom-right-radius:3px}.pager{padding-left:0;margin:20px 0;text-align:center;list-style:none}.pager:before,.pager:after{display:table;content:" "}.pager:after{clear:both}.pager:before,.pager:after{display:table;content:" "}.pager:after{clear:both}.pager li{display:inline}.pager li>a,.pager li>span{display:inline-block;padding:5px 14px;background-color:#fff;border:1px solid #ddd;border-radius:15px}.pager li>a:hover,.pager li>a:focus{text-decoration:none;background-color:#eee}.pager .next>a,.pager .next>span{float:right}.pager .previous>a,.pager .previous>span{float:left}.pager .disabled>a,.pager .disabled>a:hover,.pager .disabled>a:focus,.pager .disabled>span{color:#999;cursor:not-allowed;background-color:#fff}.label{display:inline;padding:.2em .6em .3em;font-size:75%;font-weight:bold;line-height:1;color:#fff;text-align:center;white-space:nowrap;vertical-align:baseline;border-radius:.25em}.label[href]:hover,.label[href]:focus{color:#fff;text-decoration:none;cursor:pointer}.label:empty{display:none}.label-default{background-color:#999}.label-default[href]:hover,.label-default[href]:focus{background-color:#808080}.label-primary{background-color:#428bca}.label-primary[href]:hover,.label-primary[href]:focus{background-color:#3071a9}.label-success{background-color:#5cb85c}.label-success[href]:hover,.label-success[href]:focus{background-color:#449d44}.label-info{background-color:#5bc0de}.label-info[href]:hover,.label-info[href]:focus{background-color:#31b0d5}.label-warning{background-color:#f0ad4e}.label-warning[href]:hover,.label-warning[href]:focus{background-color:#ec971f}.label-danger{background-color:#d9534f}.label-danger[href]:hover,.label-danger[href]:focus{background-color:#c9302c}.badge{display:inline-block;min-width:10px;padding:3px 7px;font-size:12px;font-weight:bold;line-height:1;color:#fff;text-align:center;white-space:nowrap;vertical-align:baseline;background-color:#999;border-radius:10px}.badge:empty{display:none}a.badge:hover,a.badge:focus{color:#fff;text-decoration:none;cursor:pointer}.btn .badge{position:relative;top:-1px}a.list-group-item.active>.badge,.nav-pills>.active>a>.badge{color:#428bca;background-color:#fff}.nav-pills>li>a>.badge{margin-left:3px}.jumbotron{padding:30px;margin-bottom:30px;font-size:21px;font-weight:200;line-height:2.1428571435;color:inherit;background-color:#eee}.jumbotron h1{line-height:1;color:inherit}.jumbotron p{line-height:1.4}.container .jumbotron{border-radius:6px}@media screen and (min-width:768px){.jumbotron{padding-top:48px;padding-bottom:48px}.container .jumbotron{padding-right:60px;padding-left:60px}.jumbotron h1{font-size:63px}}.thumbnail{display:inline-block;display:block;height:auto;max-width:100%;padding:4px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.thumbnail>img{display:block;height:auto;max-width:100%}a.thumbnail:hover,a.thumbnail:focus{border-color:#428bca}.thumbnail>img{margin-right:auto;margin-left:auto}.thumbnail .caption{padding:9px;color:#333}.alert{padding:15px;margin-bottom:20px;border:1px solid transparent;border-radius:4px}.alert h4{margin-top:0;color:inherit}.alert .alert-link{font-weight:bold}.alert>p,.alert>ul{margin-bottom:0}.alert>p+p{margin-top:5px}.alert-dismissable{padding-right:35px}.alert-dismissable .close{position:relative;top:-2px;right:-21px;color:inherit}.alert-success{color:#468847;background-color:#dff0d8;border-color:#d6e9c6}.alert-success hr{border-top-color:#c9e2b3}.alert-success .alert-link{color:#356635}.alert-info{color:#3a87ad;background-color:#d9edf7;border-color:#bce8f1}.alert-info hr{border-top-color:#a6e1ec}.alert-info .alert-link{color:#2d6987}.alert-warning{color:#c09853;background-color:#fcf8e3;border-color:#fbeed5}.alert-warning hr{border-top-color:#f8e5be}.alert-warning .alert-link{color:#a47e3c}.alert-danger{color:#b94a48;background-color:#f2dede;border-color:#eed3d7}.alert-danger hr{border-top-color:#e6c1c7}.alert-danger .alert-link{color:#953b39}@-webkit-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-moz-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-o-keyframes progress-bar-stripes{from{background-position:0 0}to{background-position:40px 0}}@keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}.progress{height:20px;margin-bottom:20px;overflow:hidden;background-color:#f5f5f5;border-radius:4px;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1)}.progress-bar{float:left;width:0;height:100%;font-size:12px;color:#fff;text-align:center;background-color:#428bca;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);-webkit-transition:width .6s ease;transition:width .6s ease}.progress-striped .progress-bar{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-size:40px 40px}.progress.active .progress-bar{-webkit-animation:progress-bar-stripes 2s linear infinite;-moz-animation:progress-bar-stripes 2s linear infinite;-ms-animation:progress-bar-stripes 2s linear infinite;-o-animation:progress-bar-stripes 2s linear infinite;animation:progress-bar-stripes 2s linear infinite}.progress-bar-success{background-color:#5cb85c}.progress-striped .progress-bar-success{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-bar-info{background-color:#5bc0de}.progress-striped .progress-bar-info{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-bar-warning{background-color:#f0ad4e}.progress-striped .progress-bar-warning{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-bar-danger{background-color:#d9534f}.progress-striped .progress-bar-danger{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.media,.media-body{overflow:hidden;zoom:1}.media,.media .media{margin-top:15px}.media:first-child{margin-top:0}.media-object{display:block}.media-heading{margin:0 0 5px}.media>.pull-left{margin-right:10px}.media>.pull-right{margin-left:10px}.media-list{padding-left:0;list-style:none}.list-group{padding-left:0;margin-bottom:20px}.list-group-item{position:relative;display:block;padding:10px 15px;margin-bottom:-1px;background-color:#fff;border:1px solid #ddd}.list-group-item:first-child{border-top-right-radius:4px;border-top-left-radius:4px}.list-group-item:last-child{margin-bottom:0;border-bottom-right-radius:4px;border-bottom-left-radius:4px}.list-group-item>.badge{float:right}.list-group-item>.badge+.badge{margin-right:5px}a.list-group-item{color:#555}a.list-group-item .list-group-item-heading{color:#333}a.list-group-item:hover,a.list-group-item:focus{text-decoration:none;background-color:#f5f5f5}.list-group-item.active,.list-group-item.active:hover,.list-group-item.active:focus{z-index:2;color:#fff;background-color:#428bca;border-color:#428bca}.list-group-item.active .list-group-item-heading,.list-group-item.active:hover .list-group-item-heading,.list-group-item.active:focus .list-group-item-heading{color:inherit}.list-group-item.active .list-group-item-text,.list-group-item.active:hover .list-group-item-text,.list-group-item.active:focus .list-group-item-text{color:#e1edf7}.list-group-item-heading{margin-top:0;margin-bottom:5px}.list-group-item-text{margin-bottom:0;line-height:1.3}.panel{margin-bottom:20px;background-color:#fff;border:1px solid transparent;border-radius:4px;-webkit-box-shadow:0 1px 1px rgba(0,0,0,0.05);box-shadow:0 1px 1px rgba(0,0,0,0.05)}.panel-body{padding:15px}.panel-body:before,.panel-body:after{display:table;content:" "}.panel-body:after{clear:both}.panel-body:before,.panel-body:after{display:table;content:" "}.panel-body:after{clear:both}.panel>.list-group{margin-bottom:0}.panel>.list-group .list-group-item{border-width:1px 0}.panel>.list-group .list-group-item:first-child{border-top-right-radius:0;border-top-left-radius:0}.panel>.list-group .list-group-item:last-child{border-bottom:0}.panel-heading+.list-group .list-group-item:first-child{border-top-width:0}.panel>.table{margin-bottom:0}.panel>.panel-body+.table{border-top:1px solid #ddd}.panel-heading{padding:10px 15px;border-bottom:1px solid transparent;border-top-right-radius:3px;border-top-left-radius:3px}.panel-title{margin-top:0;margin-bottom:0;font-size:16px}.panel-title>a{color:inherit}.panel-footer{padding:10px 15px;background-color:#f5f5f5;border-top:1px solid #ddd;border-bottom-right-radius:3px;border-bottom-left-radius:3px}.panel-group .panel{margin-bottom:0;overflow:hidden;border-radius:4px}.panel-group .panel+.panel{margin-top:5px}.panel-group .panel-heading{border-bottom:0}.panel-group .panel-heading+.panel-collapse .panel-body{border-top:1px solid #ddd}.panel-group .panel-footer{border-top:0}.panel-group .panel-footer+.panel-collapse .panel-body{border-bottom:1px solid #ddd}.panel-default{border-color:#ddd}.panel-default>.panel-heading{color:#333;background-color:#f5f5f5;border-color:#ddd}.panel-default>.panel-heading+.panel-collapse .panel-body{border-top-color:#ddd}.panel-default>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#ddd}.panel-primary{border-color:#428bca}.panel-primary>.panel-heading{color:#fff;background-color:#428bca;border-color:#428bca}.panel-primary>.panel-heading+.panel-collapse .panel-body{border-top-color:#428bca}.panel-primary>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#428bca}.panel-success{border-color:#d6e9c6}.panel-success>.panel-heading{color:#468847;background-color:#dff0d8;border-color:#d6e9c6}.panel-success>.panel-heading+.panel-collapse .panel-body{border-top-color:#d6e9c6}.panel-success>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#d6e9c6}.panel-warning{border-color:#fbeed5}.panel-warning>.panel-heading{color:#c09853;background-color:#fcf8e3;border-color:#fbeed5}.panel-warning>.panel-heading+.panel-collapse .panel-body{border-top-color:#fbeed5}.panel-warning>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#fbeed5}.panel-danger{border-color:#eed3d7}.panel-danger>.panel-heading{color:#b94a48;background-color:#f2dede;border-color:#eed3d7}.panel-danger>.panel-heading+.panel-collapse .panel-body{border-top-color:#eed3d7}.panel-danger>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#eed3d7}.panel-info{border-color:#bce8f1}.panel-info>.panel-heading{color:#3a87ad;background-color:#d9edf7;border-color:#bce8f1}.panel-info>.panel-heading+.panel-collapse .panel-body{border-top-color:#bce8f1}.panel-info>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#bce8f1}.well{min-height:20px;padding:19px;margin-bottom:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);box-shadow:inset 0 1px 1px rgba(0,0,0,0.05)}.well blockquote{border-color:#ddd;border-color:rgba(0,0,0,0.15)}.well-lg{padding:24px;border-radius:6px}.well-sm{padding:9px;border-radius:3px}.close{float:right;font-size:21px;font-weight:bold;line-height:1;color:#000;text-shadow:0 1px 0 #fff;opacity:.2;filter:alpha(opacity=20)}.close:hover,.close:focus{color:#000;text-decoration:none;cursor:pointer;opacity:.5;filter:alpha(opacity=50)}button.close{padding:0;cursor:pointer;background:transparent;border:0;-webkit-appearance:none}.modal-open{overflow:hidden}body.modal-open,.modal-open .navbar-fixed-top,.modal-open .navbar-fixed-bottom{margin-right:15px}.modal{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;display:none;overflow:auto;overflow-y:scroll}.modal.fade .modal-dialog{-webkit-transform:translate(0,-25%);-ms-transform:translate(0,-25%);transform:translate(0,-25%);-webkit-transition:-webkit-transform .3s ease-out;-moz-transition:-moz-transform .3s ease-out;-o-transition:-o-transform .3s ease-out;transition:transform .3s ease-out}.modal.in .modal-dialog{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0)}.modal-dialog{z-index:1050;width:auto;padding:10px;margin-right:auto;margin-left:auto}.modal-content{position:relative;background-color:#fff;border:1px solid #999;border:1px solid rgba(0,0,0,0.2);border-radius:6px;outline:0;-webkit-box-shadow:0 3px 9px rgba(0,0,0,0.5);box-shadow:0 3px 9px rgba(0,0,0,0.5);background-clip:padding-box}.modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1030;background-color:#000}.modal-backdrop.fade{opacity:0;filter:alpha(opacity=0)}.modal-backdrop.in{opacity:.5;filter:alpha(opacity=50)}.modal-header{min-height:16.428571429px;padding:15px;border-bottom:1px solid #e5e5e5}.modal-header .close{margin-top:-2px}.modal-title{margin:0;line-height:1.428571429}.modal-body{position:relative;padding:20px}.modal-footer{padding:19px 20px 20px;margin-top:15px;text-align:right;border-top:1px solid #e5e5e5}.modal-footer:before,.modal-footer:after{display:table;content:" "}.modal-footer:after{clear:both}.modal-footer:before,.modal-footer:after{display:table;content:" "}.modal-footer:after{clear:both}.modal-footer .btn+.btn{margin-bottom:0;margin-left:5px}.modal-footer .btn-group .btn+.btn{margin-left:-1px}.modal-footer .btn-block+.btn-block{margin-left:0}@media screen and (min-width:768px){.modal-dialog{right:auto;left:50%;width:600px;padding-top:30px;padding-bottom:30px}.modal-content{-webkit-box-shadow:0 5px 15px rgba(0,0,0,0.5);box-shadow:0 5px 15px rgba(0,0,0,0.5)}}.tooltip{position:absolute;z-index:1030;display:block;font-size:12px;line-height:1.4;opacity:0;filter:alpha(opacity=0);visibility:visible}.tooltip.in{opacity:.9;filter:alpha(opacity=90)}.tooltip.top{padding:5px 0;margin-top:-3px}.tooltip.right{padding:0 5px;margin-left:3px}.tooltip.bottom{padding:5px 0;margin-top:3px}.tooltip.left{padding:0 5px;margin-left:-3px}.tooltip-inner{max-width:200px;padding:3px 8px;color:#fff;text-align:center;text-decoration:none;background-color:#000;border-radius:4px}.tooltip-arrow{position:absolute;width:0;height:0;border-color:transparent;border-style:solid}.tooltip.top .tooltip-arrow{bottom:0;left:50%;margin-left:-5px;border-top-color:#000;border-width:5px 5px 0}.tooltip.top-left .tooltip-arrow{bottom:0;left:5px;border-top-color:#000;border-width:5px 5px 0}.tooltip.top-right .tooltip-arrow{right:5px;bottom:0;border-top-color:#000;border-width:5px 5px 0}.tooltip.right .tooltip-arrow{top:50%;left:0;margin-top:-5px;border-right-color:#000;border-width:5px 5px 5px 0}.tooltip.left .tooltip-arrow{top:50%;right:0;margin-top:-5px;border-left-color:#000;border-width:5px 0 5px 5px}.tooltip.bottom .tooltip-arrow{top:0;left:50%;margin-left:-5px;border-bottom-color:#000;border-width:0 5px 5px}.tooltip.bottom-left .tooltip-arrow{top:0;left:5px;border-bottom-color:#000;border-width:0 5px 5px}.tooltip.bottom-right .tooltip-arrow{top:0;right:5px;border-bottom-color:#000;border-width:0 5px 5px}.popover{position:absolute;top:0;left:0;z-index:1010;display:none;max-width:276px;padding:1px;text-align:left;white-space:normal;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 5px 10px rgba(0,0,0,0.2);box-shadow:0 5px 10px rgba(0,0,0,0.2);background-clip:padding-box}.popover.top{margin-top:-10px}.popover.right{margin-left:10px}.popover.bottom{margin-top:10px}.popover.left{margin-left:-10px}.popover-title{padding:8px 14px;margin:0;font-size:14px;font-weight:normal;line-height:18px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;border-radius:5px 5px 0 0}.popover-content{padding:9px 14px}.popover .arrow,.popover .arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid}.popover .arrow{border-width:11px}.popover .arrow:after{border-width:10px;content:""}.popover.top .arrow{bottom:-11px;left:50%;margin-left:-11px;border-top-color:#999;border-top-color:rgba(0,0,0,0.25);border-bottom-width:0}.popover.top .arrow:after{bottom:1px;margin-left:-10px;border-top-color:#fff;border-bottom-width:0;content:" "}.popover.right .arrow{top:50%;left:-11px;margin-top:-11px;border-right-color:#999;border-right-color:rgba(0,0,0,0.25);border-left-width:0}.popover.right .arrow:after{bottom:-10px;left:1px;border-right-color:#fff;border-left-width:0;content:" "}.popover.bottom .arrow{top:-11px;left:50%;margin-left:-11px;border-bottom-color:#999;border-bottom-color:rgba(0,0,0,0.25);border-top-width:0}.popover.bottom .arrow:after{top:1px;margin-left:-10px;border-bottom-color:#fff;border-top-width:0;content:" "}.popover.left .arrow{top:50%;right:-11px;margin-top:-11px;border-left-color:#999;border-left-color:rgba(0,0,0,0.25);border-right-width:0}.popover.left .arrow:after{right:1px;bottom:-10px;border-left-color:#fff;border-right-width:0;content:" "}.carousel{position:relative}.carousel-inner{position:relative;width:100%;overflow:hidden}.carousel-inner>.item{position:relative;display:none;-webkit-transition:.6s ease-in-out left;transition:.6s ease-in-out left}.carousel-inner>.item>img,.carousel-inner>.item>a>img{display:block;height:auto;max-width:100%;line-height:1}.carousel-inner>.active,.carousel-inner>.next,.carousel-inner>.prev{display:block}.carousel-inner>.active{left:0}.carousel-inner>.next,.carousel-inner>.prev{position:absolute;top:0;width:100%}.carousel-inner>.next{left:100%}.carousel-inner>.prev{left:-100%}.carousel-inner>.next.left,.carousel-inner>.prev.right{left:0}.carousel-inner>.active.left{left:-100%}.carousel-inner>.active.right{left:100%}.carousel-control{position:absolute;top:0;bottom:0;left:0;width:15%;font-size:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6);opacity:.5;filter:alpha(opacity=50)}.carousel-control.left{background-image:-webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.5)),to(rgba(0,0,0,0.0001)));background-image:-webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.5) 0),color-stop(rgba(0,0,0,0.0001) 100%));background-image:-moz-linear-gradient(left,rgba(0,0,0,0.5) 0,rgba(0,0,0,0.0001) 100%);background-image:linear-gradient(to right,rgba(0,0,0,0.5) 0,rgba(0,0,0,0.0001) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000',endColorstr='#00000000',GradientType=1)}.carousel-control.right{right:0;left:auto;background-image:-webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.0001)),to(rgba(0,0,0,0.5)));background-image:-webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.0001) 0),color-stop(rgba(0,0,0,0.5) 100%));background-image:-moz-linear-gradient(left,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.5) 100%);background-image:linear-gradient(to right,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.5) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000',endColorstr='#80000000',GradientType=1)}.carousel-control:hover,.carousel-control:focus{color:#fff;text-decoration:none;opacity:.9;filter:alpha(opacity=90)}.carousel-control .icon-prev,.carousel-control .icon-next,.carousel-control .glyphicon-chevron-left,.carousel-control .glyphicon-chevron-right{position:absolute;top:50%;left:50%;z-index:5;display:inline-block}.carousel-control .icon-prev,.carousel-control .icon-next{width:20px;height:20px;margin-top:-10px;margin-left:-10px;font-family:serif}.carousel-control .icon-prev:before{content:'\2039'}.carousel-control .icon-next:before{content:'\203a'}.carousel-indicators{position:absolute;bottom:10px;left:50%;z-index:15;width:60%;padding-left:0;margin-left:-30%;text-align:center;list-style:none}.carousel-indicators li{display:inline-block;width:10px;height:10px;margin:1px;text-indent:-999px;cursor:pointer;border:1px solid #fff;border-radius:10px}.carousel-indicators .active{width:12px;height:12px;margin:0;background-color:#fff}.carousel-caption{position:absolute;right:15%;bottom:20px;left:15%;z-index:10;padding-top:20px;padding-bottom:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6)}.carousel-caption .btn{text-shadow:none}@media screen and (min-width:768px){.carousel-control .icon-prev,.carousel-control .icon-next{width:30px;height:30px;margin-top:-15px;margin-left:-15px;font-size:30px}.carousel-caption{right:20%;left:20%;padding-bottom:30px}.carousel-indicators{bottom:20px}}.clearfix:before,.clearfix:after{display:table;content:" "}.clearfix:after{clear:both}.pull-right{float:right!important}.pull-left{float:left!important}.hide{display:none!important}.show{display:block!important}.invisible{visibility:hidden}.text-hide{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}.affix{position:fixed}@-ms-viewport{width:device-width}@media screen and (max-width:400px){@-ms-viewport{width:320px}}.hidden{display:none!important;visibility:hidden!important}.visible-xs{display:none!important}tr.visible-xs{display:none!important}th.visible-xs,td.visible-xs{display:none!important}@media(max-width:767px){.visible-xs{display:block!important}tr.visible-xs{display:table-row!important}th.visible-xs,td.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-xs.visible-sm{display:block!important}tr.visible-xs.visible-sm{display:table-row!important}th.visible-xs.visible-sm,td.visible-xs.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-xs.visible-md{display:block!important}tr.visible-xs.visible-md{display:table-row!important}th.visible-xs.visible-md,td.visible-xs.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-xs.visible-lg{display:block!important}tr.visible-xs.visible-lg{display:table-row!important}th.visible-xs.visible-lg,td.visible-xs.visible-lg{display:table-cell!important}}.visible-sm{display:none!important}tr.visible-sm{display:none!important}th.visible-sm,td.visible-sm{display:none!important}@media(max-width:767px){.visible-sm.visible-xs{display:block!important}tr.visible-sm.visible-xs{display:table-row!important}th.visible-sm.visible-xs,td.visible-sm.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-sm{display:block!important}tr.visible-sm{display:table-row!important}th.visible-sm,td.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-sm.visible-md{display:block!important}tr.visible-sm.visible-md{display:table-row!important}th.visible-sm.visible-md,td.visible-sm.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-sm.visible-lg{display:block!important}tr.visible-sm.visible-lg{display:table-row!important}th.visible-sm.visible-lg,td.visible-sm.visible-lg{display:table-cell!important}}.visible-md{display:none!important}tr.visible-md{display:none!important}th.visible-md,td.visible-md{display:none!important}@media(max-width:767px){.visible-md.visible-xs{display:block!important}tr.visible-md.visible-xs{display:table-row!important}th.visible-md.visible-xs,td.visible-md.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-md.visible-sm{display:block!important}tr.visible-md.visible-sm{display:table-row!important}th.visible-md.visible-sm,td.visible-md.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-md{display:block!important}tr.visible-md{display:table-row!important}th.visible-md,td.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-md.visible-lg{display:block!important}tr.visible-md.visible-lg{display:table-row!important}th.visible-md.visible-lg,td.visible-md.visible-lg{display:table-cell!important}}.visible-lg{display:none!important}tr.visible-lg{display:none!important}th.visible-lg,td.visible-lg{display:none!important}@media(max-width:767px){.visible-lg.visible-xs{display:block!important}tr.visible-lg.visible-xs{display:table-row!important}th.visible-lg.visible-xs,td.visible-lg.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-lg.visible-sm{display:block!important}tr.visible-lg.visible-sm{display:table-row!important}th.visible-lg.visible-sm,td.visible-lg.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-lg.visible-md{display:block!important}tr.visible-lg.visible-md{display:table-row!important}th.visible-lg.visible-md,td.visible-lg.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-lg{display:block!important}tr.visible-lg{display:table-row!important}th.visible-lg,td.visible-lg{display:table-cell!important}}.hidden-xs{display:block!important}tr.hidden-xs{display:table-row!important}th.hidden-xs,td.hidden-xs{display:table-cell!important}@media(max-width:767px){.hidden-xs{display:none!important}tr.hidden-xs{display:none!important}th.hidden-xs,td.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-xs.hidden-sm{display:none!important}tr.hidden-xs.hidden-sm{display:none!important}th.hidden-xs.hidden-sm,td.hidden-xs.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-xs.hidden-md{display:none!important}tr.hidden-xs.hidden-md{display:none!important}th.hidden-xs.hidden-md,td.hidden-xs.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-xs.hidden-lg{display:none!important}tr.hidden-xs.hidden-lg{display:none!important}th.hidden-xs.hidden-lg,td.hidden-xs.hidden-lg{display:none!important}}.hidden-sm{display:block!important}tr.hidden-sm{display:table-row!important}th.hidden-sm,td.hidden-sm{display:table-cell!important}@media(max-width:767px){.hidden-sm.hidden-xs{display:none!important}tr.hidden-sm.hidden-xs{display:none!important}th.hidden-sm.hidden-xs,td.hidden-sm.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-sm{display:none!important}tr.hidden-sm{display:none!important}th.hidden-sm,td.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-sm.hidden-md{display:none!important}tr.hidden-sm.hidden-md{display:none!important}th.hidden-sm.hidden-md,td.hidden-sm.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-sm.hidden-lg{display:none!important}tr.hidden-sm.hidden-lg{display:none!important}th.hidden-sm.hidden-lg,td.hidden-sm.hidden-lg{display:none!important}}.hidden-md{display:block!important}tr.hidden-md{display:table-row!important}th.hidden-md,td.hidden-md{display:table-cell!important}@media(max-width:767px){.hidden-md.hidden-xs{display:none!important}tr.hidden-md.hidden-xs{display:none!important}th.hidden-md.hidden-xs,td.hidden-md.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-md.hidden-sm{display:none!important}tr.hidden-md.hidden-sm{display:none!important}th.hidden-md.hidden-sm,td.hidden-md.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-md{display:none!important}tr.hidden-md{display:none!important}th.hidden-md,td.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-md.hidden-lg{display:none!important}tr.hidden-md.hidden-lg{display:none!important}th.hidden-md.hidden-lg,td.hidden-md.hidden-lg{display:none!important}}.hidden-lg{display:block!important}tr.hidden-lg{display:table-row!important}th.hidden-lg,td.hidden-lg{display:table-cell!important}@media(max-width:767px){.hidden-lg.hidden-xs{display:none!important}tr.hidden-lg.hidden-xs{display:none!important}th.hidden-lg.hidden-xs,td.hidden-lg.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-lg.hidden-sm{display:none!important}tr.hidden-lg.hidden-sm{display:none!important}th.hidden-lg.hidden-sm,td.hidden-lg.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-lg.hidden-md{display:none!important}tr.hidden-lg.hidden-md{display:none!important}th.hidden-lg.hidden-md,td.hidden-lg.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-lg{display:none!important}tr.hidden-lg{display:none!important}th.hidden-lg,td.hidden-lg{display:none!important}}.visible-print{display:none!important}tr.visible-print{display:none!important}th.visible-print,td.visible-print{display:none!important}@media print{.visible-print{display:block!important}tr.visible-print{display:table-row!important}th.visible-print,td.visible-print{display:table-cell!important}.hidden-print{display:none!important}tr.hidden-print{display:none!important}th.hidden-print,td.hidden-print{display:none!important}}
-
-/* 
-
-Mondido PayOut style v1.7.1, (c) Mondido Payments AB 2016, hello@mondido.com
-
+* Bootstrap v3.0.0
+*
+* Copyright 2013 Twitter, Inc
+* Licensed under the Apache License v2.0
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Designed and built with all the love in the world by @mdo and @fat.
+*//*! normalize.css v2.1.0 | MIT License | git.io/normalize */article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}audio,canvas,video{display:inline-block}audio:not([controls]){display:none;height:0}[hidden]{display:none}html{font-family:sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}body{margin:0}a:focus{outline:thin dotted}a:active,a:hover{outline:0}h1{margin:.67em 0;font-size:2em}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}dfn{font-style:italic}hr{height:0;-moz-box-sizing:content-box;box-sizing:content-box}mark{color:#000;background:#ff0}code,kbd,pre,samp{font-family:monospace,serif;font-size:1em}pre{white-space:pre-wrap}q{quotes:"\201C" "\201D" "\2018" "\2019"}small{font-size:80%}sub,sup{position:relative;font-size:75%;line-height:0;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:0}fieldset{padding:.35em .625em .75em;margin:0 2px;border:1px solid #c0c0c0}legend{padding:0;border:0}button,input,select,textarea{margin:0;font-family:inherit;font-size:100%}button,input{line-height:normal}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{cursor:pointer;-webkit-appearance:button}button[disabled],html input[disabled]{cursor:default}input[type="checkbox"],input[type="radio"]{padding:0;box-sizing:border-box}input[type="search"]{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;-webkit-appearance:textfield}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}button::-moz-focus-inner,input::-moz-focus-inner{padding:0;border:0}textarea{overflow:auto;vertical-align:top}table{border-collapse:collapse;border-spacing:0}@media print{*{color:#000!important;text-shadow:none!important;background:transparent!important;box-shadow:none!important}a,a:visited{text-decoration:underline}a[href]:after{content:" (" attr(href) ")"}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100%!important}@page{margin:2cm .5cm}p,h2,h3{orphans:3;widows:3}h2,h3{page-break-after:avoid}.navbar{display:none}.table td,.table th{background-color:#fff!important}.btn>.caret,.dropup>.btn>.caret{border-top-color:#000!important}.label{border:1px solid #000}.table{border-collapse:collapse!important}.table-bordered th,.table-bordered td{border:1px solid #ddd!important}}*,*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}html{font-size:62.5%;-webkit-tap-highlight-color:rgba(0,0,0,0)}body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:14px;line-height:1.428571429;color:#333;background-color:#fff}input,button,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}button,input,select[multiple],textarea{background-image:none}a{color:#428bca;text-decoration:none}a:hover,a:focus{color:#2a6496;text-decoration:underline}a:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}img{vertical-align:middle}.img-responsive{display:block;height:auto;max-width:100%}.img-rounded{border-radius:6px}.img-thumbnail{display:inline-block;height:auto;max-width:100%;padding:4px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.img-circle{border-radius:50%}hr{margin-top:20px;margin-bottom:20px;border:0;border-top:1px solid #eee}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);border:0}p{margin:0 0 10px}.lead{margin-bottom:20px;font-size:16.099999999999998px;font-weight:200;line-height:1.4}@media(min-width:768px){.lead{font-size:21px}}small{font-size:85%}cite{font-style:normal}.text-muted{color:#999}.text-primary{color:#428bca}.text-warning{color:#c09853}.text-danger{color:#b94a48}.text-success{color:#468847}.text-info{color:#3a87ad}.text-left{text-align:left}.text-right{text-align:right}.text-center{text-align:center}h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;font-weight:500;line-height:1.1}h1 small,h2 small,h3 small,h4 small,h5 small,h6 small,.h1 small,.h2 small,.h3 small,.h4 small,.h5 small,.h6 small{font-weight:normal;line-height:1;color:#999}h1,h2,h3{margin-top:20px;margin-bottom:10px}h4,h5,h6{margin-top:10px;margin-bottom:10px}h1,.h1{font-size:36px}h2,.h2{font-size:30px}h3,.h3{font-size:24px}h4,.h4{font-size:18px}h5,.h5{font-size:14px}h6,.h6{font-size:12px}h1 small,.h1 small{font-size:24px}h2 small,.h2 small{font-size:18px}h3 small,.h3 small,h4 small,.h4 small{font-size:14px}.page-header{padding-bottom:9px;margin:40px 0 20px;border-bottom:1px solid #eee}ul,ol{margin-top:0;margin-bottom:10px}ul ul,ol ul,ul ol,ol ol{margin-bottom:0}.list-unstyled{padding-left:0;list-style:none}.list-inline{padding-left:0;list-style:none}.list-inline>li{display:inline-block;padding-right:5px;padding-left:5px}dl{margin-bottom:20px}dt,dd{line-height:1.428571429}dt{font-weight:bold}dd{margin-left:0}@media(min-width:768px){.dl-horizontal dt{float:left;width:160px;overflow:hidden;clear:left;text-align:right;text-overflow:ellipsis;white-space:nowrap}.dl-horizontal dd{margin-left:180px}.dl-horizontal dd:before,.dl-horizontal dd:after{display:table;content:" "}.dl-horizontal dd:after{clear:both}.dl-horizontal dd:before,.dl-horizontal dd:after{display:table;content:" "}.dl-horizontal dd:after{clear:both}}abbr[title],abbr[data-original-title]{cursor:help;border-bottom:1px dotted #999}abbr.initialism{font-size:90%;text-transform:uppercase}blockquote{padding:10px 20px;margin:0 0 20px;border-left:5px solid #eee}blockquote p{font-size:17.5px;font-weight:300;line-height:1.25}blockquote p:last-child{margin-bottom:0}blockquote small{display:block;line-height:1.428571429;color:#999}blockquote small:before{content:'\2014 \00A0'}blockquote.pull-right{padding-right:15px;padding-left:0;border-right:5px solid #eee;border-left:0}blockquote.pull-right p,blockquote.pull-right small{text-align:right}blockquote.pull-right small:before{content:''}blockquote.pull-right small:after{content:'\00A0 \2014'}q:before,q:after,blockquote:before,blockquote:after{content:""}address{display:block;margin-bottom:20px;font-style:normal;line-height:1.428571429}code,pre{font-family:Monaco,Menlo,Consolas,"Courier New",monospace}code{padding:2px 4px;font-size:90%;color:#c7254e;white-space:nowrap;background-color:#f9f2f4;border-radius:4px}pre{display:block;padding:9.5px;margin:0 0 10px;font-size:13px;line-height:1.428571429;color:#333;word-break:break-all;word-wrap:break-word;background-color:#f5f5f5;border:1px solid #ccc;border-radius:4px}pre.prettyprint{margin-bottom:20px}pre code{padding:0;font-size:inherit;color:inherit;white-space:pre-wrap;background-color:transparent;border:0}.pre-scrollable{max-height:340px;overflow-y:scroll}.container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto}.container:before,.container:after{display:table;content:" "}.container:after{clear:both}.container:before,.container:after{display:table;content:" "}.container:after{clear:both}.row{margin-right:-15px;margin-left:-15px}.row:before,.row:after{display:table;content:" "}.row:after{clear:both}.row:before,.row:after{display:table;content:" "}.row:after{clear:both}.col-xs-1,.col-xs-2,.col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xs-10,.col-xs-11,.col-xs-12,.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11,.col-sm-12,.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11,.col-md-12,.col-lg-1,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-lg-10,.col-lg-11,.col-lg-12{position:relative;min-height:1px;padding-right:15px;padding-left:15px}.col-xs-1,.col-xs-2,.col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xs-10,.col-xs-11{float:left}.col-xs-1{width:8.333333333333332%}.col-xs-2{width:16.666666666666664%}.col-xs-3{width:25%}.col-xs-4{width:33.33333333333333%}.col-xs-5{width:41.66666666666667%}.col-xs-6{width:50%}.col-xs-7{width:58.333333333333336%}.col-xs-8{width:66.66666666666666%}.col-xs-9{width:75%}.col-xs-10{width:83.33333333333334%}.col-xs-11{width:91.66666666666666%}.col-xs-12{width:100%}@media(min-width:768px){.container{max-width:750px}.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11{float:left}.col-sm-1{width:8.333333333333332%}.col-sm-2{width:16.666666666666664%}.col-sm-3{width:25%}.col-sm-4{width:33.33333333333333%}.col-sm-5{width:41.66666666666667%}.col-sm-6{width:50%}.col-sm-7{width:58.333333333333336%}.col-sm-8{width:66.66666666666666%}.col-sm-9{width:75%}.col-sm-10{width:83.33333333333334%}.col-sm-11{width:91.66666666666666%}.col-sm-12{width:100%}.col-sm-push-1{left:8.333333333333332%}.col-sm-push-2{left:16.666666666666664%}.col-sm-push-3{left:25%}.col-sm-push-4{left:33.33333333333333%}.col-sm-push-5{left:41.66666666666667%}.col-sm-push-6{left:50%}.col-sm-push-7{left:58.333333333333336%}.col-sm-push-8{left:66.66666666666666%}.col-sm-push-9{left:75%}.col-sm-push-10{left:83.33333333333334%}.col-sm-push-11{left:91.66666666666666%}.col-sm-pull-1{right:8.333333333333332%}.col-sm-pull-2{right:16.666666666666664%}.col-sm-pull-3{right:25%}.col-sm-pull-4{right:33.33333333333333%}.col-sm-pull-5{right:41.66666666666667%}.col-sm-pull-6{right:50%}.col-sm-pull-7{right:58.333333333333336%}.col-sm-pull-8{right:66.66666666666666%}.col-sm-pull-9{right:75%}.col-sm-pull-10{right:83.33333333333334%}.col-sm-pull-11{right:91.66666666666666%}.col-sm-offset-1{margin-left:8.333333333333332%}.col-sm-offset-2{margin-left:16.666666666666664%}.col-sm-offset-3{margin-left:25%}.col-sm-offset-4{margin-left:33.33333333333333%}.col-sm-offset-5{margin-left:41.66666666666667%}.col-sm-offset-6{margin-left:50%}.col-sm-offset-7{margin-left:58.333333333333336%}.col-sm-offset-8{margin-left:66.66666666666666%}.col-sm-offset-9{margin-left:75%}.col-sm-offset-10{margin-left:83.33333333333334%}.col-sm-offset-11{margin-left:91.66666666666666%}}@media(min-width:992px){.container{max-width:970px}.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11{float:left}.col-md-1{width:8.333333333333332%}.col-md-2{width:16.666666666666664%}.col-md-3{width:25%}.col-md-4{width:33.33333333333333%}.col-md-5{width:41.66666666666667%}.col-md-6{width:50%}.col-md-7{width:58.333333333333336%}.col-md-8{width:66.66666666666666%}.col-md-9{width:75%}.col-md-10{width:83.33333333333334%}.col-md-11{width:91.66666666666666%}.col-md-12{width:100%}.col-md-push-0{left:auto}.col-md-push-1{left:8.333333333333332%}.col-md-push-2{left:16.666666666666664%}.col-md-push-3{left:25%}.col-md-push-4{left:33.33333333333333%}.col-md-push-5{left:41.66666666666667%}.col-md-push-6{left:50%}.col-md-push-7{left:58.333333333333336%}.col-md-push-8{left:66.66666666666666%}.col-md-push-9{left:75%}.col-md-push-10{left:83.33333333333334%}.col-md-push-11{left:91.66666666666666%}.col-md-pull-0{right:auto}.col-md-pull-1{right:8.333333333333332%}.col-md-pull-2{right:16.666666666666664%}.col-md-pull-3{right:25%}.col-md-pull-4{right:33.33333333333333%}.col-md-pull-5{right:41.66666666666667%}.col-md-pull-6{right:50%}.col-md-pull-7{right:58.333333333333336%}.col-md-pull-8{right:66.66666666666666%}.col-md-pull-9{right:75%}.col-md-pull-10{right:83.33333333333334%}.col-md-pull-11{right:91.66666666666666%}.col-md-offset-0{margin-left:0}.col-md-offset-1{margin-left:8.333333333333332%}.col-md-offset-2{margin-left:16.666666666666664%}.col-md-offset-3{margin-left:25%}.col-md-offset-4{margin-left:33.33333333333333%}.col-md-offset-5{margin-left:41.66666666666667%}.col-md-offset-6{margin-left:50%}.col-md-offset-7{margin-left:58.333333333333336%}.col-md-offset-8{margin-left:66.66666666666666%}.col-md-offset-9{margin-left:75%}.col-md-offset-10{margin-left:83.33333333333334%}.col-md-offset-11{margin-left:91.66666666666666%}}@media(min-width:1200px){.container{max-width:1170px}.col-lg-1,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-lg-10,.col-lg-11{float:left}.col-lg-1{width:8.333333333333332%}.col-lg-2{width:16.666666666666664%}.col-lg-3{width:25%}.col-lg-4{width:33.33333333333333%}.col-lg-5{width:41.66666666666667%}.col-lg-6{width:50%}.col-lg-7{width:58.333333333333336%}.col-lg-8{width:66.66666666666666%}.col-lg-9{width:75%}.col-lg-10{width:83.33333333333334%}.col-lg-11{width:91.66666666666666%}.col-lg-12{width:100%}.col-lg-push-0{left:auto}.col-lg-push-1{left:8.333333333333332%}.col-lg-push-2{left:16.666666666666664%}.col-lg-push-3{left:25%}.col-lg-push-4{left:33.33333333333333%}.col-lg-push-5{left:41.66666666666667%}.col-lg-push-6{left:50%}.col-lg-push-7{left:58.333333333333336%}.col-lg-push-8{left:66.66666666666666%}.col-lg-push-9{left:75%}.col-lg-push-10{left:83.33333333333334%}.col-lg-push-11{left:91.66666666666666%}.col-lg-pull-0{right:auto}.col-lg-pull-1{right:8.333333333333332%}.col-lg-pull-2{right:16.666666666666664%}.col-lg-pull-3{right:25%}.col-lg-pull-4{right:33.33333333333333%}.col-lg-pull-5{right:41.66666666666667%}.col-lg-pull-6{right:50%}.col-lg-pull-7{right:58.333333333333336%}.col-lg-pull-8{right:66.66666666666666%}.col-lg-pull-9{right:75%}.col-lg-pull-10{right:83.33333333333334%}.col-lg-pull-11{right:91.66666666666666%}.col-lg-offset-0{margin-left:0}.col-lg-offset-1{margin-left:8.333333333333332%}.col-lg-offset-2{margin-left:16.666666666666664%}.col-lg-offset-3{margin-left:25%}.col-lg-offset-4{margin-left:33.33333333333333%}.col-lg-offset-5{margin-left:41.66666666666667%}.col-lg-offset-6{margin-left:50%}.col-lg-offset-7{margin-left:58.333333333333336%}.col-lg-offset-8{margin-left:66.66666666666666%}.col-lg-offset-9{margin-left:75%}.col-lg-offset-10{margin-left:83.33333333333334%}.col-lg-offset-11{margin-left:91.66666666666666%}}table{max-width:100%;background-color:transparent}th{text-align:left}.table{width:100%;margin-bottom:20px}.table thead>tr>th,.table tbody>tr>th,.table tfoot>tr>th,.table thead>tr>td,.table tbody>tr>td,.table tfoot>tr>td{padding:8px;line-height:1.428571429;vertical-align:top;border-top:1px solid #ddd}.table thead>tr>th{vertical-align:bottom;border-bottom:2px solid #ddd}.table caption+thead tr:first-child th,.table colgroup+thead tr:first-child th,.table thead:first-child tr:first-child th,.table caption+thead tr:first-child td,.table colgroup+thead tr:first-child td,.table thead:first-child tr:first-child td{border-top:0}.table tbody+tbody{border-top:2px solid #ddd}.table .table{background-color:#fff}.table-condensed thead>tr>th,.table-condensed tbody>tr>th,.table-condensed tfoot>tr>th,.table-condensed thead>tr>td,.table-condensed tbody>tr>td,.table-condensed tfoot>tr>td{padding:5px}.table-bordered{border:1px solid #ddd}.table-bordered>thead>tr>th,.table-bordered>tbody>tr>th,.table-bordered>tfoot>tr>th,.table-bordered>thead>tr>td,.table-bordered>tbody>tr>td,.table-bordered>tfoot>tr>td{border:1px solid #ddd}.table-bordered>thead>tr>th,.table-bordered>thead>tr>td{border-bottom-width:2px}.table-striped>tbody>tr:nth-child(odd)>td,.table-striped>tbody>tr:nth-child(odd)>th{background-color:#f9f9f9}.table-hover>tbody>tr:hover>td,.table-hover>tbody>tr:hover>th{background-color:#f5f5f5}table col[class*="col-"]{display:table-column;float:none}table td[class*="col-"],table th[class*="col-"]{display:table-cell;float:none}.table>thead>tr>td.active,.table>tbody>tr>td.active,.table>tfoot>tr>td.active,.table>thead>tr>th.active,.table>tbody>tr>th.active,.table>tfoot>tr>th.active,.table>thead>tr.active>td,.table>tbody>tr.active>td,.table>tfoot>tr.active>td,.table>thead>tr.active>th,.table>tbody>tr.active>th,.table>tfoot>tr.active>th{background-color:#f5f5f5}.table>thead>tr>td.success,.table>tbody>tr>td.success,.table>tfoot>tr>td.success,.table>thead>tr>th.success,.table>tbody>tr>th.success,.table>tfoot>tr>th.success,.table>thead>tr.success>td,.table>tbody>tr.success>td,.table>tfoot>tr.success>td,.table>thead>tr.success>th,.table>tbody>tr.success>th,.table>tfoot>tr.success>th{background-color:#dff0d8;border-color:#d6e9c6}.table-hover>tbody>tr>td.success:hover,.table-hover>tbody>tr>th.success:hover,.table-hover>tbody>tr.success:hover>td{background-color:#d0e9c6;border-color:#c9e2b3}.table>thead>tr>td.danger,.table>tbody>tr>td.danger,.table>tfoot>tr>td.danger,.table>thead>tr>th.danger,.table>tbody>tr>th.danger,.table>tfoot>tr>th.danger,.table>thead>tr.danger>td,.table>tbody>tr.danger>td,.table>tfoot>tr.danger>td,.table>thead>tr.danger>th,.table>tbody>tr.danger>th,.table>tfoot>tr.danger>th{background-color:#f2dede;border-color:#eed3d7}.table-hover>tbody>tr>td.danger:hover,.table-hover>tbody>tr>th.danger:hover,.table-hover>tbody>tr.danger:hover>td{background-color:#ebcccc;border-color:#e6c1c7}.table>thead>tr>td.warning,.table>tbody>tr>td.warning,.table>tfoot>tr>td.warning,.table>thead>tr>th.warning,.table>tbody>tr>th.warning,.table>tfoot>tr>th.warning,.table>thead>tr.warning>td,.table>tbody>tr.warning>td,.table>tfoot>tr.warning>td,.table>thead>tr.warning>th,.table>tbody>tr.warning>th,.table>tfoot>tr.warning>th{background-color:#fcf8e3;border-color:#fbeed5}.table-hover>tbody>tr>td.warning:hover,.table-hover>tbody>tr>th.warning:hover,.table-hover>tbody>tr.warning:hover>td{background-color:#faf2cc;border-color:#f8e5be}@media(max-width:768px){.table-responsive{width:100%;margin-bottom:15px;overflow-x:scroll;overflow-y:hidden;border:1px solid #ddd}.table-responsive>.table{margin-bottom:0;background-color:#fff}.table-responsive>.table>thead>tr>th,.table-responsive>.table>tbody>tr>th,.table-responsive>.table>tfoot>tr>th,.table-responsive>.table>thead>tr>td,.table-responsive>.table>tbody>tr>td,.table-responsive>.table>tfoot>tr>td{white-space:nowrap}.table-responsive>.table-bordered{border:0}.table-responsive>.table-bordered>thead>tr>th:first-child,.table-responsive>.table-bordered>tbody>tr>th:first-child,.table-responsive>.table-bordered>tfoot>tr>th:first-child,.table-responsive>.table-bordered>thead>tr>td:first-child,.table-responsive>.table-bordered>tbody>tr>td:first-child,.table-responsive>.table-bordered>tfoot>tr>td:first-child{border-left:0}.table-responsive>.table-bordered>thead>tr>th:last-child,.table-responsive>.table-bordered>tbody>tr>th:last-child,.table-responsive>.table-bordered>tfoot>tr>th:last-child,.table-responsive>.table-bordered>thead>tr>td:last-child,.table-responsive>.table-bordered>tbody>tr>td:last-child,.table-responsive>.table-bordered>tfoot>tr>td:last-child{border-right:0}.table-responsive>.table-bordered>thead>tr:last-child>th,.table-responsive>.table-bordered>tbody>tr:last-child>th,.table-responsive>.table-bordered>tfoot>tr:last-child>th,.table-responsive>.table-bordered>thead>tr:last-child>td,.table-responsive>.table-bordered>tbody>tr:last-child>td,.table-responsive>.table-bordered>tfoot>tr:last-child>td{border-bottom:0}}fieldset{padding:0;margin:0;border:0}legend{display:block;width:100%;padding:0;margin-bottom:20px;font-size:21px;line-height:inherit;color:#333;border:0;border-bottom:1px solid #e5e5e5}label{display:inline-block;margin-bottom:5px;font-weight:bold}input[type="search"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}input[type="radio"],input[type="checkbox"]{margin:4px 0 0;margin-top:1px \9;line-height:normal}input[type="file"]{display:block}select[multiple],select[size]{height:auto}select optgroup{font-family:inherit;font-size:inherit;font-style:inherit}input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}input[type="number"]::-webkit-outer-spin-button,input[type="number"]::-webkit-inner-spin-button{height:auto}.form-control:-moz-placeholder{color:#999}.form-control::-moz-placeholder{color:#999}.form-control:-ms-input-placeholder{color:#999}.form-control::-webkit-input-placeholder{color:#999}.form-control{display:block;width:100%;height:34px;padding:6px 12px;font-size:14px;line-height:1.428571429;color:#555;vertical-align:middle;background-color:#fff;border:1px solid #ccc;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s,box-shadow ease-in-out .15s}.form-control:focus{border-color:#66afe9;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6)}.form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control{cursor:not-allowed;background-color:#eee}textarea.form-control{height:auto}.form-group{margin-bottom:15px}.radio,.checkbox{display:block;min-height:20px;padding-left:20px;margin-top:10px;margin-bottom:10px;vertical-align:middle}.radio label,.checkbox label{display:inline;margin-bottom:0;font-weight:normal;cursor:pointer}.radio input[type="radio"],.radio-inline input[type="radio"],.checkbox input[type="checkbox"],.checkbox-inline input[type="checkbox"]{float:left;margin-left:-20px}.radio+.radio,.checkbox+.checkbox{margin-top:-5px}.radio-inline,.checkbox-inline{display:inline-block;padding-left:20px;margin-bottom:0;font-weight:normal;vertical-align:middle;cursor:pointer}.radio-inline+.radio-inline,.checkbox-inline+.checkbox-inline{margin-top:0;margin-left:10px}input[type="radio"][disabled],input[type="checkbox"][disabled],.radio[disabled],.radio-inline[disabled],.checkbox[disabled],.checkbox-inline[disabled],fieldset[disabled] input[type="radio"],fieldset[disabled] input[type="checkbox"],fieldset[disabled] .radio,fieldset[disabled] .radio-inline,fieldset[disabled] .checkbox,fieldset[disabled] .checkbox-inline{cursor:not-allowed}.input-sm{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-sm{height:30px;line-height:30px}textarea.input-sm{height:auto}.input-lg{height:45px;padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}select.input-lg{height:45px;line-height:45px}textarea.input-lg{height:auto}.has-warning .help-block,.has-warning .control-label{color:#c09853}.has-warning .form-control{border-color:#c09853;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-warning .form-control:focus{border-color:#a47e3c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #dbc59e}.has-warning .input-group-addon{color:#c09853;background-color:#fcf8e3;border-color:#c09853}.has-error .help-block,.has-error .control-label{color:#b94a48}.has-error .form-control{border-color:#b94a48;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-error .form-control:focus{border-color:#953b39;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #d59392}.has-error .input-group-addon{color:#b94a48;background-color:#f2dede;border-color:#b94a48}.has-success .help-block,.has-success .control-label{color:#468847}.has-success .form-control{border-color:#468847;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-success .form-control:focus{border-color:#356635;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #7aba7b}.has-success .input-group-addon{color:#468847;background-color:#dff0d8;border-color:#468847}.form-control-static{padding-top:7px;margin-bottom:0}.help-block{display:block;margin-top:5px;margin-bottom:10px;color:#737373}@media(min-width:768px){.form-inline .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}.form-inline .form-control{display:inline-block}.form-inline .radio,.form-inline .checkbox{display:inline-block;padding-left:0;margin-top:0;margin-bottom:0}.form-inline .radio input[type="radio"],.form-inline .checkbox input[type="checkbox"]{float:none;margin-left:0}}.form-horizontal .control-label,.form-horizontal .radio,.form-horizontal .checkbox,.form-horizontal .radio-inline,.form-horizontal .checkbox-inline{padding-top:7px;margin-top:0;margin-bottom:0}.form-horizontal .form-group{margin-right:-15px;margin-left:-15px}.form-horizontal .form-group:before,.form-horizontal .form-group:after{display:table;content:" "}.form-horizontal .form-group:after{clear:both}.form-horizontal .form-group:before,.form-horizontal .form-group:after{display:table;content:" "}.form-horizontal .form-group:after{clear:both}@media(min-width:768px){.form-horizontal .control-label{text-align:right}}.btn{display:inline-block;padding:6px 12px;margin-bottom:0;font-size:14px;font-weight:normal;line-height:1.428571429;text-align:center;white-space:nowrap;vertical-align:middle;cursor:pointer;border:1px solid transparent;border-radius:4px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;-o-user-select:none;user-select:none}.btn:focus{outline:thin dotted #333;outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}.btn:hover,.btn:focus{color:#333;text-decoration:none}.btn:active,.btn.active{background-image:none;outline:0;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn.disabled,.btn[disabled],fieldset[disabled] .btn{pointer-events:none;cursor:not-allowed;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;box-shadow:none}.btn-default{color:#333;background-color:#fff;border-color:#ccc}.btn-default:hover,.btn-default:focus,.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{color:#333;background-color:#ebebeb;border-color:#adadad}.btn-default:active,.btn-default.active,.open .dropdown-toggle.btn-default{background-image:none}.btn-default.disabled,.btn-default[disabled],fieldset[disabled] .btn-default,.btn-default.disabled:hover,.btn-default[disabled]:hover,fieldset[disabled] .btn-default:hover,.btn-default.disabled:focus,.btn-default[disabled]:focus,fieldset[disabled] .btn-default:focus,.btn-default.disabled:active,.btn-default[disabled]:active,fieldset[disabled] .btn-default:active,.btn-default.disabled.active,.btn-default[disabled].active,fieldset[disabled] .btn-default.active{background-color:#fff;border-color:#ccc}.btn-primary{color:#fff;background-color:#428bca;border-color:#357ebd}.btn-primary:hover,.btn-primary:focus,.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{color:#fff;background-color:#3276b1;border-color:#285e8e}.btn-primary:active,.btn-primary.active,.open .dropdown-toggle.btn-primary{background-image:none}.btn-primary.disabled,.btn-primary[disabled],fieldset[disabled] .btn-primary,.btn-primary.disabled:hover,.btn-primary[disabled]:hover,fieldset[disabled] .btn-primary:hover,.btn-primary.disabled:focus,.btn-primary[disabled]:focus,fieldset[disabled] .btn-primary:focus,.btn-primary.disabled:active,.btn-primary[disabled]:active,fieldset[disabled] .btn-primary:active,.btn-primary.disabled.active,.btn-primary[disabled].active,fieldset[disabled] .btn-primary.active{background-color:#428bca;border-color:#357ebd}.btn-warning{color:#fff;background-color:#f0ad4e;border-color:#eea236}.btn-warning:hover,.btn-warning:focus,.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{color:#fff;background-color:#ed9c28;border-color:#d58512}.btn-warning:active,.btn-warning.active,.open .dropdown-toggle.btn-warning{background-image:none}.btn-warning.disabled,.btn-warning[disabled],fieldset[disabled] .btn-warning,.btn-warning.disabled:hover,.btn-warning[disabled]:hover,fieldset[disabled] .btn-warning:hover,.btn-warning.disabled:focus,.btn-warning[disabled]:focus,fieldset[disabled] .btn-warning:focus,.btn-warning.disabled:active,.btn-warning[disabled]:active,fieldset[disabled] .btn-warning:active,.btn-warning.disabled.active,.btn-warning[disabled].active,fieldset[disabled] .btn-warning.active{background-color:#f0ad4e;border-color:#eea236}.btn-danger{color:#fff;background-color:#d9534f;border-color:#d43f3a}.btn-danger:hover,.btn-danger:focus,.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{color:#fff;background-color:#d2322d;border-color:#ac2925}.btn-danger:active,.btn-danger.active,.open .dropdown-toggle.btn-danger{background-image:none}.btn-danger.disabled,.btn-danger[disabled],fieldset[disabled] .btn-danger,.btn-danger.disabled:hover,.btn-danger[disabled]:hover,fieldset[disabled] .btn-danger:hover,.btn-danger.disabled:focus,.btn-danger[disabled]:focus,fieldset[disabled] .btn-danger:focus,.btn-danger.disabled:active,.btn-danger[disabled]:active,fieldset[disabled] .btn-danger:active,.btn-danger.disabled.active,.btn-danger[disabled].active,fieldset[disabled] .btn-danger.active{background-color:#d9534f;border-color:#d43f3a}.btn-success{color:#fff;background-color:#5cb85c;border-color:#4cae4c}.btn-success:hover,.btn-success:focus,.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{color:#fff;background-color:#47a447;border-color:#398439}.btn-success:active,.btn-success.active,.open .dropdown-toggle.btn-success{background-image:none}.btn-success.disabled,.btn-success[disabled],fieldset[disabled] .btn-success,.btn-success.disabled:hover,.btn-success[disabled]:hover,fieldset[disabled] .btn-success:hover,.btn-success.disabled:focus,.btn-success[disabled]:focus,fieldset[disabled] .btn-success:focus,.btn-success.disabled:active,.btn-success[disabled]:active,fieldset[disabled] .btn-success:active,.btn-success.disabled.active,.btn-success[disabled].active,fieldset[disabled] .btn-success.active{background-color:#5cb85c;border-color:#4cae4c}.btn-info{color:#fff;background-color:#5bc0de;border-color:#46b8da}.btn-info:hover,.btn-info:focus,.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{color:#fff;background-color:#39b3d7;border-color:#269abc}.btn-info:active,.btn-info.active,.open .dropdown-toggle.btn-info{background-image:none}.btn-info.disabled,.btn-info[disabled],fieldset[disabled] .btn-info,.btn-info.disabled:hover,.btn-info[disabled]:hover,fieldset[disabled] .btn-info:hover,.btn-info.disabled:focus,.btn-info[disabled]:focus,fieldset[disabled] .btn-info:focus,.btn-info.disabled:active,.btn-info[disabled]:active,fieldset[disabled] .btn-info:active,.btn-info.disabled.active,.btn-info[disabled].active,fieldset[disabled] .btn-info.active{background-color:#5bc0de;border-color:#46b8da}.btn-link{font-weight:normal;color:#428bca;cursor:pointer;border-radius:0}.btn-link,.btn-link:active,.btn-link[disabled],fieldset[disabled] .btn-link{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}.btn-link,.btn-link:hover,.btn-link:focus,.btn-link:active{border-color:transparent}.btn-link:hover,.btn-link:focus{color:#2a6496;text-decoration:underline;background-color:transparent}.btn-link[disabled]:hover,fieldset[disabled] .btn-link:hover,.btn-link[disabled]:focus,fieldset[disabled] .btn-link:focus{color:#999;text-decoration:none}.btn-lg{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}.btn-sm,.btn-xs{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}.btn-xs{padding:1px 5px}.btn-block{display:block;width:100%;padding-right:0;padding-left:0}.btn-block+.btn-block{margin-top:5px}input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"].btn-block{width:100%}.fade{opacity:0;-webkit-transition:opacity .15s linear;transition:opacity .15s linear}.fade.in{opacity:1}.collapse{display:none}.collapse.in{display:block}.collapsing{position:relative;height:0;overflow:hidden;-webkit-transition:height .35s ease;transition:height .35s ease}@font-face{font-family:'Glyphicons Halflings';src:url('../fonts/glyphicons-halflings-regular.eot');src:url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'),url('../fonts/glyphicons-halflings-regular.woff') format('woff'),url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'),url('../fonts/glyphicons-halflings-regular.svg#glyphicons-halflingsregular') format('svg')}.glyphicon{position:relative;top:1px;display:inline-block;font-family:'Glyphicons Halflings';-webkit-font-smoothing:antialiased;font-style:normal;font-weight:normal;line-height:1}.glyphicon-asterisk:before{content:"\2a"}.glyphicon-plus:before{content:"\2b"}.glyphicon-euro:before{content:"\20ac"}.glyphicon-minus:before{content:"\2212"}.glyphicon-cloud:before{content:"\2601"}.glyphicon-envelope:before{content:"\2709"}.glyphicon-pencil:before{content:"\270f"}.glyphicon-glass:before{content:"\e001"}.glyphicon-music:before{content:"\e002"}.glyphicon-search:before{content:"\e003"}.glyphicon-heart:before{content:"\e005"}.glyphicon-star:before{content:"\e006"}.glyphicon-star-empty:before{content:"\e007"}.glyphicon-user:before{content:"\e008"}.glyphicon-film:before{content:"\e009"}.glyphicon-th-large:before{content:"\e010"}.glyphicon-th:before{content:"\e011"}.glyphicon-th-list:before{content:"\e012"}.glyphicon-ok:before{content:"\e013"}.glyphicon-remove:before{content:"\e014"}.glyphicon-zoom-in:before{content:"\e015"}.glyphicon-zoom-out:before{content:"\e016"}.glyphicon-off:before{content:"\e017"}.glyphicon-signal:before{content:"\e018"}.glyphicon-cog:before{content:"\e019"}.glyphicon-trash:before{content:"\e020"}.glyphicon-home:before{content:"\e021"}.glyphicon-file:before{content:"\e022"}.glyphicon-time:before{content:"\e023"}.glyphicon-road:before{content:"\e024"}.glyphicon-download-alt:before{content:"\e025"}.glyphicon-download:before{content:"\e026"}.glyphicon-upload:before{content:"\e027"}.glyphicon-inbox:before{content:"\e028"}.glyphicon-play-circle:before{content:"\e029"}.glyphicon-repeat:before{content:"\e030"}.glyphicon-refresh:before{content:"\e031"}.glyphicon-list-alt:before{content:"\e032"}.glyphicon-flag:before{content:"\e034"}.glyphicon-headphones:before{content:"\e035"}.glyphicon-volume-off:before{content:"\e036"}.glyphicon-volume-down:before{content:"\e037"}.glyphicon-volume-up:before{content:"\e038"}.glyphicon-qrcode:before{content:"\e039"}.glyphicon-barcode:before{content:"\e040"}.glyphicon-tag:before{content:"\e041"}.glyphicon-tags:before{content:"\e042"}.glyphicon-book:before{content:"\e043"}.glyphicon-print:before{content:"\e045"}.glyphicon-font:before{content:"\e047"}.glyphicon-bold:before{content:"\e048"}.glyphicon-italic:before{content:"\e049"}.glyphicon-text-height:before{content:"\e050"}.glyphicon-text-width:before{content:"\e051"}.glyphicon-align-left:before{content:"\e052"}.glyphicon-align-center:before{content:"\e053"}.glyphicon-align-right:before{content:"\e054"}.glyphicon-align-justify:before{content:"\e055"}.glyphicon-list:before{content:"\e056"}.glyphicon-indent-left:before{content:"\e057"}.glyphicon-indent-right:before{content:"\e058"}.glyphicon-facetime-video:before{content:"\e059"}.glyphicon-picture:before{content:"\e060"}.glyphicon-map-marker:before{content:"\e062"}.glyphicon-adjust:before{content:"\e063"}.glyphicon-tint:before{content:"\e064"}.glyphicon-edit:before{content:"\e065"}.glyphicon-share:before{content:"\e066"}.glyphicon-check:before{content:"\e067"}.glyphicon-move:before{content:"\e068"}.glyphicon-step-backward:before{content:"\e069"}.glyphicon-fast-backward:before{content:"\e070"}.glyphicon-backward:before{content:"\e071"}.glyphicon-play:before{content:"\e072"}.glyphicon-pause:before{content:"\e073"}.glyphicon-stop:before{content:"\e074"}.glyphicon-forward:before{content:"\e075"}.glyphicon-fast-forward:before{content:"\e076"}.glyphicon-step-forward:before{content:"\e077"}.glyphicon-eject:before{content:"\e078"}.glyphicon-chevron-left:before{content:"\e079"}.glyphicon-chevron-right:before{content:"\e080"}.glyphicon-plus-sign:before{content:"\e081"}.glyphicon-minus-sign:before{content:"\e082"}.glyphicon-remove-sign:before{content:"\e083"}.glyphicon-ok-sign:before{content:"\e084"}.glyphicon-question-sign:before{content:"\e085"}.glyphicon-info-sign:before{content:"\e086"}.glyphicon-screenshot:before{content:"\e087"}.glyphicon-remove-circle:before{content:"\e088"}.glyphicon-ok-circle:before{content:"\e089"}.glyphicon-ban-circle:before{content:"\e090"}.glyphicon-arrow-left:before{content:"\e091"}.glyphicon-arrow-right:before{content:"\e092"}.glyphicon-arrow-up:before{content:"\e093"}.glyphicon-arrow-down:before{content:"\e094"}.glyphicon-share-alt:before{content:"\e095"}.glyphicon-resize-full:before{content:"\e096"}.glyphicon-resize-small:before{content:"\e097"}.glyphicon-exclamation-sign:before{content:"\e101"}.glyphicon-gift:before{content:"\e102"}.glyphicon-leaf:before{content:"\e103"}.glyphicon-eye-open:before{content:"\e105"}.glyphicon-eye-close:before{content:"\e106"}.glyphicon-warning-sign:before{content:"\e107"}.glyphicon-plane:before{content:"\e108"}.glyphicon-random:before{content:"\e110"}.glyphicon-comment:before{content:"\e111"}.glyphicon-magnet:before{content:"\e112"}.glyphicon-chevron-up:before{content:"\e113"}.glyphicon-chevron-down:before{content:"\e114"}.glyphicon-retweet:before{content:"\e115"}.glyphicon-shopping-cart:before{content:"\e116"}.glyphicon-folder-close:before{content:"\e117"}.glyphicon-folder-open:before{content:"\e118"}.glyphicon-resize-vertical:before{content:"\e119"}.glyphicon-resize-horizontal:before{content:"\e120"}.glyphicon-hdd:before{content:"\e121"}.glyphicon-bullhorn:before{content:"\e122"}.glyphicon-certificate:before{content:"\e124"}.glyphicon-thumbs-up:before{content:"\e125"}.glyphicon-thumbs-down:before{content:"\e126"}.glyphicon-hand-right:before{content:"\e127"}.glyphicon-hand-left:before{content:"\e128"}.glyphicon-hand-up:before{content:"\e129"}.glyphicon-hand-down:before{content:"\e130"}.glyphicon-circle-arrow-right:before{content:"\e131"}.glyphicon-circle-arrow-left:before{content:"\e132"}.glyphicon-circle-arrow-up:before{content:"\e133"}.glyphicon-circle-arrow-down:before{content:"\e134"}.glyphicon-globe:before{content:"\e135"}.glyphicon-tasks:before{content:"\e137"}.glyphicon-filter:before{content:"\e138"}.glyphicon-fullscreen:before{content:"\e140"}.glyphicon-dashboard:before{content:"\e141"}.glyphicon-heart-empty:before{content:"\e143"}.glyphicon-link:before{content:"\e144"}.glyphicon-phone:before{content:"\e145"}.glyphicon-usd:before{content:"\e148"}.glyphicon-gbp:before{content:"\e149"}.glyphicon-sort:before{content:"\e150"}.glyphicon-sort-by-alphabet:before{content:"\e151"}.glyphicon-sort-by-alphabet-alt:before{content:"\e152"}.glyphicon-sort-by-order:before{content:"\e153"}.glyphicon-sort-by-order-alt:before{content:"\e154"}.glyphicon-sort-by-attributes:before{content:"\e155"}.glyphicon-sort-by-attributes-alt:before{content:"\e156"}.glyphicon-unchecked:before{content:"\e157"}.glyphicon-expand:before{content:"\e158"}.glyphicon-collapse-down:before{content:"\e159"}.glyphicon-collapse-up:before{content:"\e160"}.glyphicon-log-in:before{content:"\e161"}.glyphicon-flash:before{content:"\e162"}.glyphicon-log-out:before{content:"\e163"}.glyphicon-new-window:before{content:"\e164"}.glyphicon-record:before{content:"\e165"}.glyphicon-save:before{content:"\e166"}.glyphicon-open:before{content:"\e167"}.glyphicon-saved:before{content:"\e168"}.glyphicon-import:before{content:"\e169"}.glyphicon-export:before{content:"\e170"}.glyphicon-send:before{content:"\e171"}.glyphicon-floppy-disk:before{content:"\e172"}.glyphicon-floppy-saved:before{content:"\e173"}.glyphicon-floppy-remove:before{content:"\e174"}.glyphicon-floppy-save:before{content:"\e175"}.glyphicon-floppy-open:before{content:"\e176"}.glyphicon-credit-card:before{content:"\e177"}.glyphicon-transfer:before{content:"\e178"}.glyphicon-cutlery:before{content:"\e179"}.glyphicon-header:before{content:"\e180"}.glyphicon-compressed:before{content:"\e181"}.glyphicon-earphone:before{content:"\e182"}.glyphicon-phone-alt:before{content:"\e183"}.glyphicon-tower:before{content:"\e184"}.glyphicon-stats:before{content:"\e185"}.glyphicon-sd-video:before{content:"\e186"}.glyphicon-hd-video:before{content:"\e187"}.glyphicon-subtitles:before{content:"\e188"}.glyphicon-sound-stereo:before{content:"\e189"}.glyphicon-sound-dolby:before{content:"\e190"}.glyphicon-sound-5-1:before{content:"\e191"}.glyphicon-sound-6-1:before{content:"\e192"}.glyphicon-sound-7-1:before{content:"\e193"}.glyphicon-copyright-mark:before{content:"\e194"}.glyphicon-registration-mark:before{content:"\e195"}.glyphicon-cloud-download:before{content:"\e197"}.glyphicon-cloud-upload:before{content:"\e198"}.glyphicon-tree-conifer:before{content:"\e199"}.glyphicon-tree-deciduous:before{content:"\e200"}.glyphicon-briefcase:before{content:"\1f4bc"}.glyphicon-calendar:before{content:"\1f4c5"}.glyphicon-pushpin:before{content:"\1f4cc"}.glyphicon-paperclip:before{content:"\1f4ce"}.glyphicon-camera:before{content:"\1f4f7"}.glyphicon-lock:before{content:"\1f512"}.glyphicon-bell:before{content:"\1f514"}.glyphicon-bookmark:before{content:"\1f516"}.glyphicon-fire:before{content:"\1f525"}.glyphicon-wrench:before{content:"\1f527"}.caret{display:inline-block;width:0;height:0;margin-left:2px;vertical-align:middle;border-top:4px solid #000;border-right:4px solid transparent;border-bottom:0 dotted;border-left:4px solid transparent;content:""}.dropdown{position:relative}.dropdown-toggle:focus{outline:0}.dropdown-menu{position:absolute;top:100%;left:0;z-index:1000;display:none;float:left;min-width:160px;padding:5px 0;margin:2px 0 0;font-size:14px;list-style:none;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.15);border-radius:4px;-webkit-box-shadow:0 6px 12px rgba(0,0,0,0.175);box-shadow:0 6px 12px rgba(0,0,0,0.175);background-clip:padding-box}.dropdown-menu.pull-right{right:0;left:auto}.dropdown-menu .divider{height:1px;margin:9px 0;overflow:hidden;background-color:#e5e5e5}.dropdown-menu>li>a{display:block;padding:3px 20px;clear:both;font-weight:normal;line-height:1.428571429;color:#333;white-space:nowrap}.dropdown-menu>li>a:hover,.dropdown-menu>li>a:focus{color:#fff;text-decoration:none;background-color:#428bca}.dropdown-menu>.active>a,.dropdown-menu>.active>a:hover,.dropdown-menu>.active>a:focus{color:#fff;text-decoration:none;background-color:#428bca;outline:0}.dropdown-menu>.disabled>a,.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{color:#999}.dropdown-menu>.disabled>a:hover,.dropdown-menu>.disabled>a:focus{text-decoration:none;cursor:not-allowed;background-color:transparent;background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.open>.dropdown-menu{display:block}.open>a{outline:0}.dropdown-header{display:block;padding:3px 20px;font-size:12px;line-height:1.428571429;color:#999}.dropdown-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:990}.pull-right>.dropdown-menu{right:0;left:auto}.dropup .caret,.navbar-fixed-bottom .dropdown .caret{border-top:0 dotted;border-bottom:4px solid #000;content:""}.dropup .dropdown-menu,.navbar-fixed-bottom .dropdown .dropdown-menu{top:auto;bottom:100%;margin-bottom:1px}@media(min-width:768px){.navbar-right .dropdown-menu{right:0;left:auto}}.btn-default .caret{border-top-color:#333}.btn-primary .caret,.btn-success .caret,.btn-warning .caret,.btn-danger .caret,.btn-info .caret{border-top-color:#fff}.dropup .btn-default .caret{border-bottom-color:#333}.dropup .btn-primary .caret,.dropup .btn-success .caret,.dropup .btn-warning .caret,.dropup .btn-danger .caret,.dropup .btn-info .caret{border-bottom-color:#fff}.btn-group,.btn-group-vertical{position:relative;display:inline-block;vertical-align:middle}.btn-group>.btn,.btn-group-vertical>.btn{position:relative;float:left}.btn-group>.btn:hover,.btn-group-vertical>.btn:hover,.btn-group>.btn:focus,.btn-group-vertical>.btn:focus,.btn-group>.btn:active,.btn-group-vertical>.btn:active,.btn-group>.btn.active,.btn-group-vertical>.btn.active{z-index:2}.btn-group>.btn:focus,.btn-group-vertical>.btn:focus{outline:0}.btn-group .btn+.btn,.btn-group .btn+.btn-group,.btn-group .btn-group+.btn,.btn-group .btn-group+.btn-group{margin-left:-1px}.btn-toolbar:before,.btn-toolbar:after{display:table;content:" "}.btn-toolbar:after{clear:both}.btn-toolbar:before,.btn-toolbar:after{display:table;content:" "}.btn-toolbar:after{clear:both}.btn-toolbar .btn-group{float:left}.btn-toolbar>.btn+.btn,.btn-toolbar>.btn-group+.btn,.btn-toolbar>.btn+.btn-group,.btn-toolbar>.btn-group+.btn-group{margin-left:5px}.btn-group>.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}.btn-group>.btn:first-child{margin-left:0}.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle){border-top-right-radius:0;border-bottom-right-radius:0}.btn-group>.btn:last-child:not(:first-child),.btn-group>.dropdown-toggle:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}.btn-group>.btn-group{float:left}.btn-group>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}.btn-group>.btn-group:first-child>.btn:last-child,.btn-group>.btn-group:first-child>.dropdown-toggle{border-top-right-radius:0;border-bottom-right-radius:0}.btn-group>.btn-group:last-child>.btn:first-child{border-bottom-left-radius:0;border-top-left-radius:0}.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}.btn-group-xs>.btn{padding:5px 10px;padding:1px 5px;font-size:12px;line-height:1.5;border-radius:3px}.btn-group-sm>.btn{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}.btn-group-lg>.btn{padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}.btn-group>.btn+.dropdown-toggle{padding-right:8px;padding-left:8px}.btn-group>.btn-lg+.dropdown-toggle{padding-right:12px;padding-left:12px}.btn-group.open .dropdown-toggle{-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn .caret{margin-left:0}.btn-lg .caret{border-width:5px 5px 0;border-bottom-width:0}.dropup .btn-lg .caret{border-width:0 5px 5px}.btn-group-vertical>.btn,.btn-group-vertical>.btn-group{display:block;float:none;width:100%;max-width:100%}.btn-group-vertical>.btn-group:before,.btn-group-vertical>.btn-group:after{display:table;content:" "}.btn-group-vertical>.btn-group:after{clear:both}.btn-group-vertical>.btn-group:before,.btn-group-vertical>.btn-group:after{display:table;content:" "}.btn-group-vertical>.btn-group:after{clear:both}.btn-group-vertical>.btn-group>.btn{float:none}.btn-group-vertical>.btn+.btn,.btn-group-vertical>.btn+.btn-group,.btn-group-vertical>.btn-group+.btn,.btn-group-vertical>.btn-group+.btn-group{margin-top:-1px;margin-left:0}.btn-group-vertical>.btn:not(:first-child):not(:last-child){border-radius:0}.btn-group-vertical>.btn:first-child:not(:last-child){border-top-right-radius:4px;border-bottom-right-radius:0;border-bottom-left-radius:0}.btn-group-vertical>.btn:last-child:not(:first-child){border-top-right-radius:0;border-bottom-left-radius:4px;border-top-left-radius:0}.btn-group-vertical>.btn-group:not(:first-child):not(:last-child)>.btn{border-radius:0}.btn-group-vertical>.btn-group:first-child>.btn:last-child,.btn-group-vertical>.btn-group:first-child>.dropdown-toggle{border-bottom-right-radius:0;border-bottom-left-radius:0}.btn-group-vertical>.btn-group:last-child>.btn:first-child{border-top-right-radius:0;border-top-left-radius:0}.btn-group-justified{display:table;width:100%;border-collapse:separate;table-layout:fixed}.btn-group-justified .btn{display:table-cell;float:none;width:1%}[data-toggle="buttons"]>.btn>input[type="radio"],[data-toggle="buttons"]>.btn>input[type="checkbox"]{display:none}.input-group{position:relative;display:table;border-collapse:separate}.input-group.col{float:none;padding-right:0;padding-left:0}.input-group .form-control{width:100%;margin-bottom:0}.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn{height:45px;padding:10px 16px;font-size:18px;line-height:1.33;border-radius:6px}select.input-group-lg>.form-control,select.input-group-lg>.input-group-addon,select.input-group-lg>.input-group-btn>.btn{height:45px;line-height:45px}textarea.input-group-lg>.form-control,textarea.input-group-lg>.input-group-addon,textarea.input-group-lg>.input-group-btn>.btn{height:auto}.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-group-sm>.form-control,select.input-group-sm>.input-group-addon,select.input-group-sm>.input-group-btn>.btn{height:30px;line-height:30px}textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon,textarea.input-group-sm>.input-group-btn>.btn{height:auto}.input-group-addon,.input-group-btn,.input-group .form-control{display:table-cell}.input-group-addon:not(:first-child):not(:last-child),.input-group-btn:not(:first-child):not(:last-child),.input-group .form-control:not(:first-child):not(:last-child){border-radius:0}.input-group-addon,.input-group-btn{width:1%;white-space:nowrap;vertical-align:middle}.input-group-addon{padding:6px 12px;font-size:14px;font-weight:normal;line-height:1;text-align:center;background-color:#eee;border:1px solid #ccc;border-radius:4px}.input-group-addon.input-sm{padding:5px 10px;font-size:12px;border-radius:3px}.input-group-addon.input-lg{padding:10px 16px;font-size:18px;border-radius:6px}.input-group-addon input[type="radio"],.input-group-addon input[type="checkbox"]{margin-top:0}.input-group .form-control:first-child,.input-group-addon:first-child,.input-group-btn:first-child>.btn,.input-group-btn:first-child>.dropdown-toggle,.input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle){border-top-right-radius:0;border-bottom-right-radius:0}.input-group-addon:first-child{border-right:0}.input-group .form-control:last-child,.input-group-addon:last-child,.input-group-btn:last-child>.btn,.input-group-btn:last-child>.dropdown-toggle,.input-group-btn:first-child>.btn:not(:first-child){border-bottom-left-radius:0;border-top-left-radius:0}.input-group-addon:last-child{border-left:0}.input-group-btn{position:relative;white-space:nowrap}.input-group-btn>.btn{position:relative}.input-group-btn>.btn+.btn{margin-left:-4px}.input-group-btn>.btn:hover,.input-group-btn>.btn:active{z-index:2}.nav{padding-left:0;margin-bottom:0;list-style:none}.nav:before,.nav:after{display:table;content:" "}.nav:after{clear:both}.nav:before,.nav:after{display:table;content:" "}.nav:after{clear:both}.nav>li{position:relative;display:block}.nav>li>a{position:relative;display:block;padding:10px 15px}.nav>li>a:hover,.nav>li>a:focus{text-decoration:none;background-color:#eee}.nav>li.disabled>a{color:#999}.nav>li.disabled>a:hover,.nav>li.disabled>a:focus{color:#999;text-decoration:none;cursor:not-allowed;background-color:transparent}.nav .open>a,.nav .open>a:hover,.nav .open>a:focus{background-color:#eee;border-color:#428bca}.nav .nav-divider{height:1px;margin:9px 0;overflow:hidden;background-color:#e5e5e5}.nav>li>a>img{max-width:none}.nav-tabs{border-bottom:1px solid #ddd}.nav-tabs>li{float:left;margin-bottom:-1px}.nav-tabs>li>a{margin-right:2px;line-height:1.428571429;border:1px solid transparent;border-radius:4px 4px 0 0}.nav-tabs>li>a:hover{border-color:#eee #eee #ddd}.nav-tabs>li.active>a,.nav-tabs>li.active>a:hover,.nav-tabs>li.active>a:focus{color:#555;cursor:default;background-color:#fff;border:1px solid #ddd;border-bottom-color:transparent}.nav-tabs.nav-justified{width:100%;border-bottom:0}.nav-tabs.nav-justified>li{float:none}.nav-tabs.nav-justified>li>a{text-align:center}@media(min-width:768px){.nav-tabs.nav-justified>li{display:table-cell;width:1%}}.nav-tabs.nav-justified>li>a{margin-right:0;border-bottom:1px solid #ddd}.nav-tabs.nav-justified>.active>a{border-bottom-color:#fff}.nav-pills>li{float:left}.nav-pills>li>a{border-radius:5px}.nav-pills>li+li{margin-left:2px}.nav-pills>li.active>a,.nav-pills>li.active>a:hover,.nav-pills>li.active>a:focus{color:#fff;background-color:#428bca}.nav-stacked>li{float:none}.nav-stacked>li+li{margin-top:2px;margin-left:0}.nav-justified{width:100%}.nav-justified>li{float:none}.nav-justified>li>a{text-align:center}@media(min-width:768px){.nav-justified>li{display:table-cell;width:1%}}.nav-tabs-justified{border-bottom:0}.nav-tabs-justified>li>a{margin-right:0;border-bottom:1px solid #ddd}.nav-tabs-justified>.active>a{border-bottom-color:#fff}.tabbable:before,.tabbable:after{display:table;content:" "}.tabbable:after{clear:both}.tabbable:before,.tabbable:after{display:table;content:" "}.tabbable:after{clear:both}.tab-content>.tab-pane,.pill-content>.pill-pane{display:none}.tab-content>.active,.pill-content>.active{display:block}.nav .caret{border-top-color:#428bca;border-bottom-color:#428bca}.nav a:hover .caret{border-top-color:#2a6496;border-bottom-color:#2a6496}.nav-tabs .dropdown-menu{margin-top:-1px;border-top-right-radius:0;border-top-left-radius:0}.navbar{position:relative;z-index:1000;min-height:50px;margin-bottom:20px;border:1px solid transparent}.navbar:before,.navbar:after{display:table;content:" "}.navbar:after{clear:both}.navbar:before,.navbar:after{display:table;content:" "}.navbar:after{clear:both}@media(min-width:768px){.navbar{border-radius:4px}}.navbar-header:before,.navbar-header:after{display:table;content:" "}.navbar-header:after{clear:both}.navbar-header:before,.navbar-header:after{display:table;content:" "}.navbar-header:after{clear:both}@media(min-width:768px){.navbar-header{float:left}}.navbar-collapse{max-height:340px;padding-right:15px;padding-left:15px;overflow-x:visible;border-top:1px solid transparent;box-shadow:inset 0 1px 0 rgba(255,255,255,0.1);-webkit-overflow-scrolling:touch}.navbar-collapse:before,.navbar-collapse:after{display:table;content:" "}.navbar-collapse:after{clear:both}.navbar-collapse:before,.navbar-collapse:after{display:table;content:" "}.navbar-collapse:after{clear:both}.navbar-collapse.in{overflow-y:auto}@media(min-width:768px){.navbar-collapse{width:auto;border-top:0;box-shadow:none}.navbar-collapse.collapse{display:block!important;height:auto!important;padding-bottom:0;overflow:visible!important}.navbar-collapse.in{overflow-y:visible}.navbar-collapse .navbar-nav.navbar-left:first-child{margin-left:-15px}.navbar-collapse .navbar-nav.navbar-right:last-child{margin-right:-15px}.navbar-collapse .navbar-text:last-child{margin-right:0}}.container>.navbar-header,.container>.navbar-collapse{margin-right:-15px;margin-left:-15px}@media(min-width:768px){.container>.navbar-header,.container>.navbar-collapse{margin-right:0;margin-left:0}}.navbar-static-top{border-width:0 0 1px}@media(min-width:768px){.navbar-static-top{border-radius:0}}.navbar-fixed-top,.navbar-fixed-bottom{position:fixed;right:0;left:0;border-width:0 0 1px}@media(min-width:768px){.navbar-fixed-top,.navbar-fixed-bottom{border-radius:0}}.navbar-fixed-top{top:0;z-index:1030}.navbar-fixed-bottom{bottom:0;margin-bottom:0}.navbar-brand{float:left;padding:15px 15px;font-size:18px;line-height:20px}.navbar-brand:hover,.navbar-brand:focus{text-decoration:none}@media(min-width:768px){.navbar>.container .navbar-brand{margin-left:-15px}}.navbar-toggle{position:relative;float:right;padding:9px 10px;margin-top:8px;margin-right:15px;margin-bottom:8px;background-color:transparent;border:1px solid transparent;border-radius:4px}.navbar-toggle .icon-bar{display:block;width:22px;height:2px;border-radius:1px}.navbar-toggle .icon-bar+.icon-bar{margin-top:4px}@media(min-width:768px){.navbar-toggle{display:none}}.navbar-nav{margin:7.5px -15px}.navbar-nav>li>a{padding-top:10px;padding-bottom:10px;line-height:20px}@media(max-width:767px){.navbar-nav .open .dropdown-menu{position:static;float:none;width:auto;margin-top:0;background-color:transparent;border:0;box-shadow:none}.navbar-nav .open .dropdown-menu>li>a,.navbar-nav .open .dropdown-menu .dropdown-header{padding:5px 15px 5px 25px}.navbar-nav .open .dropdown-menu>li>a{line-height:20px}.navbar-nav .open .dropdown-menu>li>a:hover,.navbar-nav .open .dropdown-menu>li>a:focus{background-image:none}}@media(min-width:768px){.navbar-nav{float:left;margin:0}.navbar-nav>li{float:left}.navbar-nav>li>a{padding-top:15px;padding-bottom:15px}}@media(min-width:768px){.navbar-left{float:left!important}.navbar-right{float:right!important}}.navbar-form{padding:10px 15px;margin-top:8px;margin-right:-15px;margin-bottom:8px;margin-left:-15px;border-top:1px solid transparent;border-bottom:1px solid transparent;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1);box-shadow:inset 0 1px 0 rgba(255,255,255,0.1),0 1px 0 rgba(255,255,255,0.1)}@media(min-width:768px){.navbar-form .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}.navbar-form .form-control{display:inline-block}.navbar-form .radio,.navbar-form .checkbox{display:inline-block;padding-left:0;margin-top:0;margin-bottom:0}.navbar-form .radio input[type="radio"],.navbar-form .checkbox input[type="checkbox"]{float:none;margin-left:0}}@media(max-width:767px){.navbar-form .form-group{margin-bottom:5px}}@media(min-width:768px){.navbar-form{width:auto;padding-top:0;padding-bottom:0;margin-right:0;margin-left:0;border:0;-webkit-box-shadow:none;box-shadow:none}}.navbar-nav>li>.dropdown-menu{margin-top:0;border-top-right-radius:0;border-top-left-radius:0}.navbar-fixed-bottom .navbar-nav>li>.dropdown-menu{border-bottom-right-radius:0;border-bottom-left-radius:0}.navbar-nav.pull-right>li>.dropdown-menu,.navbar-nav>li>.dropdown-menu.pull-right{right:0;left:auto}.navbar-btn{margin-top:8px;margin-bottom:8px}.navbar-text{float:left;margin-top:15px;margin-bottom:15px}@media(min-width:768px){.navbar-text{margin-right:15px;margin-left:15px}}.navbar-default{background-color:#f8f8f8;border-color:#e7e7e7}.navbar-default .navbar-brand{color:#777}.navbar-default .navbar-brand:hover,.navbar-default .navbar-brand:focus{color:#5e5e5e;background-color:transparent}.navbar-default .navbar-text{color:#777}.navbar-default .navbar-nav>li>a{color:#777}.navbar-default .navbar-nav>li>a:hover,.navbar-default .navbar-nav>li>a:focus{color:#333;background-color:transparent}.navbar-default .navbar-nav>.active>a,.navbar-default .navbar-nav>.active>a:hover,.navbar-default .navbar-nav>.active>a:focus{color:#555;background-color:#e7e7e7}.navbar-default .navbar-nav>.disabled>a,.navbar-default .navbar-nav>.disabled>a:hover,.navbar-default .navbar-nav>.disabled>a:focus{color:#ccc;background-color:transparent}.navbar-default .navbar-toggle{border-color:#ddd}.navbar-default .navbar-toggle:hover,.navbar-default .navbar-toggle:focus{background-color:#ddd}.navbar-default .navbar-toggle .icon-bar{background-color:#ccc}.navbar-default .navbar-collapse,.navbar-default .navbar-form{border-color:#e6e6e6}.navbar-default .navbar-nav>.dropdown>a:hover .caret,.navbar-default .navbar-nav>.dropdown>a:focus .caret{border-top-color:#333;border-bottom-color:#333}.navbar-default .navbar-nav>.open>a,.navbar-default .navbar-nav>.open>a:hover,.navbar-default .navbar-nav>.open>a:focus{color:#555;background-color:#e7e7e7}.navbar-default .navbar-nav>.open>a .caret,.navbar-default .navbar-nav>.open>a:hover .caret,.navbar-default .navbar-nav>.open>a:focus .caret{border-top-color:#555;border-bottom-color:#555}.navbar-default .navbar-nav>.dropdown>a .caret{border-top-color:#777;border-bottom-color:#777}@media(max-width:767px){.navbar-default .navbar-nav .open .dropdown-menu>li>a{color:#777}.navbar-default .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>li>a:focus{color:#333;background-color:transparent}.navbar-default .navbar-nav .open .dropdown-menu>.active>a,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.active>a:focus{color:#555;background-color:#e7e7e7}.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-default .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#ccc;background-color:transparent}}.navbar-default .navbar-link{color:#777}.navbar-default .navbar-link:hover{color:#333}.navbar-inverse{background-color:#222;border-color:#080808}.navbar-inverse .navbar-brand{color:#999}.navbar-inverse .navbar-brand:hover,.navbar-inverse .navbar-brand:focus{color:#fff;background-color:transparent}.navbar-inverse .navbar-text{color:#999}.navbar-inverse .navbar-nav>li>a{color:#999}.navbar-inverse .navbar-nav>li>a:hover,.navbar-inverse .navbar-nav>li>a:focus{color:#fff;background-color:transparent}.navbar-inverse .navbar-nav>.active>a,.navbar-inverse .navbar-nav>.active>a:hover,.navbar-inverse .navbar-nav>.active>a:focus{color:#fff;background-color:#080808}.navbar-inverse .navbar-nav>.disabled>a,.navbar-inverse .navbar-nav>.disabled>a:hover,.navbar-inverse .navbar-nav>.disabled>a:focus{color:#444;background-color:transparent}.navbar-inverse .navbar-toggle{border-color:#333}.navbar-inverse .navbar-toggle:hover,.navbar-inverse .navbar-toggle:focus{background-color:#333}.navbar-inverse .navbar-toggle .icon-bar{background-color:#fff}.navbar-inverse .navbar-collapse,.navbar-inverse .navbar-form{border-color:#101010}.navbar-inverse .navbar-nav>.open>a,.navbar-inverse .navbar-nav>.open>a:hover,.navbar-inverse .navbar-nav>.open>a:focus{color:#fff;background-color:#080808}.navbar-inverse .navbar-nav>.dropdown>a:hover .caret{border-top-color:#fff;border-bottom-color:#fff}.navbar-inverse .navbar-nav>.dropdown>a .caret{border-top-color:#999;border-bottom-color:#999}.navbar-inverse .navbar-nav>.open>a .caret,.navbar-inverse .navbar-nav>.open>a:hover .caret,.navbar-inverse .navbar-nav>.open>a:focus .caret{border-top-color:#fff;border-bottom-color:#fff}@media(max-width:767px){.navbar-inverse .navbar-nav .open .dropdown-menu>.dropdown-header{border-color:#080808}.navbar-inverse .navbar-nav .open .dropdown-menu>li>a{color:#999}.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:focus{color:#fff;background-color:transparent}.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.active>a:focus{color:#fff;background-color:#080808}.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:hover,.navbar-inverse .navbar-nav .open .dropdown-menu>.disabled>a:focus{color:#444;background-color:transparent}}.navbar-inverse .navbar-link{color:#999}.navbar-inverse .navbar-link:hover{color:#fff}.breadcrumb{padding:8px 15px;margin-bottom:20px;list-style:none;background-color:#f5f5f5;border-radius:4px}.breadcrumb>li{display:inline-block}.breadcrumb>li+li:before{padding:0 5px;color:#ccc;content:"/\00a0"}.breadcrumb>.active{color:#999}.pagination{display:inline-block;padding-left:0;margin:20px 0;border-radius:4px}.pagination>li{display:inline}.pagination>li>a,.pagination>li>span{position:relative;float:left;padding:6px 12px;margin-left:-1px;line-height:1.428571429;text-decoration:none;background-color:#fff;border:1px solid #ddd}.pagination>li:first-child>a,.pagination>li:first-child>span{margin-left:0;border-bottom-left-radius:4px;border-top-left-radius:4px}.pagination>li:last-child>a,.pagination>li:last-child>span{border-top-right-radius:4px;border-bottom-right-radius:4px}.pagination>li>a:hover,.pagination>li>span:hover,.pagination>li>a:focus,.pagination>li>span:focus{background-color:#eee}.pagination>.active>a,.pagination>.active>span,.pagination>.active>a:hover,.pagination>.active>span:hover,.pagination>.active>a:focus,.pagination>.active>span:focus{z-index:2;color:#fff;cursor:default;background-color:#428bca;border-color:#428bca}.pagination>.disabled>span,.pagination>.disabled>a,.pagination>.disabled>a:hover,.pagination>.disabled>a:focus{color:#999;cursor:not-allowed;background-color:#fff;border-color:#ddd}.pagination-lg>li>a,.pagination-lg>li>span{padding:10px 16px;font-size:18px}.pagination-lg>li:first-child>a,.pagination-lg>li:first-child>span{border-bottom-left-radius:6px;border-top-left-radius:6px}.pagination-lg>li:last-child>a,.pagination-lg>li:last-child>span{border-top-right-radius:6px;border-bottom-right-radius:6px}.pagination-sm>li>a,.pagination-sm>li>span{padding:5px 10px;font-size:12px}.pagination-sm>li:first-child>a,.pagination-sm>li:first-child>span{border-bottom-left-radius:3px;border-top-left-radius:3px}.pagination-sm>li:last-child>a,.pagination-sm>li:last-child>span{border-top-right-radius:3px;border-bottom-right-radius:3px}.pager{padding-left:0;margin:20px 0;text-align:center;list-style:none}.pager:before,.pager:after{display:table;content:" "}.pager:after{clear:both}.pager:before,.pager:after{display:table;content:" "}.pager:after{clear:both}.pager li{display:inline}.pager li>a,.pager li>span{display:inline-block;padding:5px 14px;background-color:#fff;border:1px solid #ddd;border-radius:15px}.pager li>a:hover,.pager li>a:focus{text-decoration:none;background-color:#eee}.pager .next>a,.pager .next>span{float:right}.pager .previous>a,.pager .previous>span{float:left}.pager .disabled>a,.pager .disabled>a:hover,.pager .disabled>a:focus,.pager .disabled>span{color:#999;cursor:not-allowed;background-color:#fff}.label{display:inline;padding:.2em .6em .3em;font-size:75%;font-weight:bold;line-height:1;color:#fff;text-align:center;white-space:nowrap;vertical-align:baseline;border-radius:.25em}.label[href]:hover,.label[href]:focus{color:#fff;text-decoration:none;cursor:pointer}.label:empty{display:none}.label-default{background-color:#999}.label-default[href]:hover,.label-default[href]:focus{background-color:#808080}.label-primary{background-color:#428bca}.label-primary[href]:hover,.label-primary[href]:focus{background-color:#3071a9}.label-success{background-color:#5cb85c}.label-success[href]:hover,.label-success[href]:focus{background-color:#449d44}.label-info{background-color:#5bc0de}.label-info[href]:hover,.label-info[href]:focus{background-color:#31b0d5}.label-warning{background-color:#f0ad4e}.label-warning[href]:hover,.label-warning[href]:focus{background-color:#ec971f}.label-danger{background-color:#d9534f}.label-danger[href]:hover,.label-danger[href]:focus{background-color:#c9302c}.badge{display:inline-block;min-width:10px;padding:3px 7px;font-size:12px;font-weight:bold;line-height:1;color:#fff;text-align:center;white-space:nowrap;vertical-align:baseline;background-color:#999;border-radius:10px}.badge:empty{display:none}a.badge:hover,a.badge:focus{color:#fff;text-decoration:none;cursor:pointer}.btn .badge{position:relative;top:-1px}a.list-group-item.active>.badge,.nav-pills>.active>a>.badge{color:#428bca;background-color:#fff}.nav-pills>li>a>.badge{margin-left:3px}.jumbotron{padding:30px;margin-bottom:30px;font-size:21px;font-weight:200;line-height:2.1428571435;color:inherit;background-color:#eee}.jumbotron h1{line-height:1;color:inherit}.jumbotron p{line-height:1.4}.container .jumbotron{border-radius:6px}@media screen and (min-width:768px){.jumbotron{padding-top:48px;padding-bottom:48px}.container .jumbotron{padding-right:60px;padding-left:60px}.jumbotron h1{font-size:63px}}.thumbnail{display:inline-block;display:block;height:auto;max-width:100%;padding:4px;line-height:1.428571429;background-color:#fff;border:1px solid #ddd;border-radius:4px;-webkit-transition:all .2s ease-in-out;transition:all .2s ease-in-out}.thumbnail>img{display:block;height:auto;max-width:100%}a.thumbnail:hover,a.thumbnail:focus{border-color:#428bca}.thumbnail>img{margin-right:auto;margin-left:auto}.thumbnail .caption{padding:9px;color:#333}.alert{padding:15px;margin-bottom:20px;border:1px solid transparent;border-radius:4px}.alert h4{margin-top:0;color:inherit}.alert .alert-link{font-weight:bold}.alert>p,.alert>ul{margin-bottom:0}.alert>p+p{margin-top:5px}.alert-dismissable{padding-right:35px}.alert-dismissable .close{position:relative;top:-2px;right:-21px;color:inherit}.alert-success{color:#468847;background-color:#dff0d8;border-color:#d6e9c6}.alert-success hr{border-top-color:#c9e2b3}.alert-success .alert-link{color:#356635}.alert-info{color:#3a87ad;background-color:#d9edf7;border-color:#bce8f1}.alert-info hr{border-top-color:#a6e1ec}.alert-info .alert-link{color:#2d6987}.alert-warning{color:#c09853;background-color:#fcf8e3;border-color:#fbeed5}.alert-warning hr{border-top-color:#f8e5be}.alert-warning .alert-link{color:#a47e3c}.alert-danger{color:#b94a48;background-color:#f2dede;border-color:#eed3d7}.alert-danger hr{border-top-color:#e6c1c7}.alert-danger .alert-link{color:#953b39}@-webkit-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-moz-keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}@-o-keyframes progress-bar-stripes{from{background-position:0 0}to{background-position:40px 0}}@keyframes progress-bar-stripes{from{background-position:40px 0}to{background-position:0 0}}.progress{height:20px;margin-bottom:20px;overflow:hidden;background-color:#f5f5f5;border-radius:4px;-webkit-box-shadow:inset 0 1px 2px rgba(0,0,0,0.1);box-shadow:inset 0 1px 2px rgba(0,0,0,0.1)}.progress-bar{float:left;width:0;height:100%;font-size:12px;color:#fff;text-align:center;background-color:#428bca;-webkit-box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);box-shadow:inset 0 -1px 0 rgba(0,0,0,0.15);-webkit-transition:width .6s ease;transition:width .6s ease}.progress-striped .progress-bar{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-size:40px 40px}.progress.active .progress-bar{-webkit-animation:progress-bar-stripes 2s linear infinite;-moz-animation:progress-bar-stripes 2s linear infinite;-ms-animation:progress-bar-stripes 2s linear infinite;-o-animation:progress-bar-stripes 2s linear infinite;animation:progress-bar-stripes 2s linear infinite}.progress-bar-success{background-color:#5cb85c}.progress-striped .progress-bar-success{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-bar-info{background-color:#5bc0de}.progress-striped .progress-bar-info{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-bar-warning{background-color:#f0ad4e}.progress-striped .progress-bar-warning{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.progress-bar-danger{background-color:#d9534f}.progress-striped .progress-bar-danger{background-image:-webkit-gradient(linear,0 100%,100% 0,color-stop(0.25,rgba(255,255,255,0.15)),color-stop(0.25,transparent),color-stop(0.5,transparent),color-stop(0.5,rgba(255,255,255,0.15)),color-stop(0.75,rgba(255,255,255,0.15)),color-stop(0.75,transparent),to(transparent));background-image:-webkit-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:-moz-linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent);background-image:linear-gradient(45deg,rgba(255,255,255,0.15) 25%,transparent 25%,transparent 50%,rgba(255,255,255,0.15) 50%,rgba(255,255,255,0.15) 75%,transparent 75%,transparent)}.media,.media-body{overflow:hidden;zoom:1}.media,.media .media{margin-top:15px}.media:first-child{margin-top:0}.media-object{display:block}.media-heading{margin:0 0 5px}.media>.pull-left{margin-right:10px}.media>.pull-right{margin-left:10px}.media-list{padding-left:0;list-style:none}.list-group{padding-left:0;margin-bottom:20px}.list-group-item{position:relative;display:block;padding:10px 15px;margin-bottom:-1px;background-color:#fff;border:1px solid #ddd}.list-group-item:first-child{border-top-right-radius:4px;border-top-left-radius:4px}.list-group-item:last-child{margin-bottom:0;border-bottom-right-radius:4px;border-bottom-left-radius:4px}.list-group-item>.badge{float:right}.list-group-item>.badge+.badge{margin-right:5px}a.list-group-item{color:#555}a.list-group-item .list-group-item-heading{color:#333}a.list-group-item:hover,a.list-group-item:focus{text-decoration:none;background-color:#f5f5f5}.list-group-item.active,.list-group-item.active:hover,.list-group-item.active:focus{z-index:2;color:#fff;background-color:#428bca;border-color:#428bca}.list-group-item.active .list-group-item-heading,.list-group-item.active:hover .list-group-item-heading,.list-group-item.active:focus .list-group-item-heading{color:inherit}.list-group-item.active .list-group-item-text,.list-group-item.active:hover .list-group-item-text,.list-group-item.active:focus .list-group-item-text{color:#e1edf7}.list-group-item-heading{margin-top:0;margin-bottom:5px}.list-group-item-text{margin-bottom:0;line-height:1.3}.panel{margin-bottom:20px;background-color:#fff;border:1px solid transparent;border-radius:4px;-webkit-box-shadow:0 1px 1px rgba(0,0,0,0.05);box-shadow:0 1px 1px rgba(0,0,0,0.05)}.panel-body{padding:15px}.panel-body:before,.panel-body:after{display:table;content:" "}.panel-body:after{clear:both}.panel-body:before,.panel-body:after{display:table;content:" "}.panel-body:after{clear:both}.panel>.list-group{margin-bottom:0}.panel>.list-group .list-group-item{border-width:1px 0}.panel>.list-group .list-group-item:first-child{border-top-right-radius:0;border-top-left-radius:0}.panel>.list-group .list-group-item:last-child{border-bottom:0}.panel-heading+.list-group .list-group-item:first-child{border-top-width:0}.panel>.table{margin-bottom:0}.panel>.panel-body+.table{border-top:1px solid #ddd}.panel-heading{padding:10px 15px;border-bottom:1px solid transparent;border-top-right-radius:3px;border-top-left-radius:3px}.panel-title{margin-top:0;margin-bottom:0;font-size:16px}.panel-title>a{color:inherit}.panel-footer{padding:10px 15px;background-color:#f5f5f5;border-top:1px solid #ddd;border-bottom-right-radius:3px;border-bottom-left-radius:3px}.panel-group .panel{margin-bottom:0;overflow:hidden;border-radius:4px}.panel-group .panel+.panel{margin-top:5px}.panel-group .panel-heading{border-bottom:0}.panel-group .panel-heading+.panel-collapse .panel-body{border-top:1px solid #ddd}.panel-group .panel-footer{border-top:0}.panel-group .panel-footer+.panel-collapse .panel-body{border-bottom:1px solid #ddd}.panel-default{border-color:#ddd}.panel-default>.panel-heading{color:#333;background-color:#f5f5f5;border-color:#ddd}.panel-default>.panel-heading+.panel-collapse .panel-body{border-top-color:#ddd}.panel-default>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#ddd}.panel-primary{border-color:#428bca}.panel-primary>.panel-heading{color:#fff;background-color:#428bca;border-color:#428bca}.panel-primary>.panel-heading+.panel-collapse .panel-body{border-top-color:#428bca}.panel-primary>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#428bca}.panel-success{border-color:#d6e9c6}.panel-success>.panel-heading{color:#468847;background-color:#dff0d8;border-color:#d6e9c6}.panel-success>.panel-heading+.panel-collapse .panel-body{border-top-color:#d6e9c6}.panel-success>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#d6e9c6}.panel-warning{border-color:#fbeed5}.panel-warning>.panel-heading{color:#c09853;background-color:#fcf8e3;border-color:#fbeed5}.panel-warning>.panel-heading+.panel-collapse .panel-body{border-top-color:#fbeed5}.panel-warning>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#fbeed5}.panel-danger{border-color:#eed3d7}.panel-danger>.panel-heading{color:#b94a48;background-color:#f2dede;border-color:#eed3d7}.panel-danger>.panel-heading+.panel-collapse .panel-body{border-top-color:#eed3d7}.panel-danger>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#eed3d7}.panel-info{border-color:#bce8f1}.panel-info>.panel-heading{color:#3a87ad;background-color:#d9edf7;border-color:#bce8f1}.panel-info>.panel-heading+.panel-collapse .panel-body{border-top-color:#bce8f1}.panel-info>.panel-footer+.panel-collapse .panel-body{border-bottom-color:#bce8f1}.well{min-height:20px;padding:19px;margin-bottom:20px;background-color:#f5f5f5;border:1px solid #e3e3e3;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.05);box-shadow:inset 0 1px 1px rgba(0,0,0,0.05)}.well blockquote{border-color:#ddd;border-color:rgba(0,0,0,0.15)}.well-lg{padding:24px;border-radius:6px}.well-sm{padding:9px;border-radius:3px}.close{float:right;font-size:21px;font-weight:bold;line-height:1;color:#000;text-shadow:0 1px 0 #fff;opacity:.2;filter:alpha(opacity=20)}.close:hover,.close:focus{color:#000;text-decoration:none;cursor:pointer;opacity:.5;filter:alpha(opacity=50)}button.close{padding:0;cursor:pointer;background:transparent;border:0;-webkit-appearance:none}.modal-open{overflow:hidden}body.modal-open,.modal-open .navbar-fixed-top,.modal-open .navbar-fixed-bottom{margin-right:15px}.modal{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;display:none;overflow:auto;overflow-y:scroll}.modal.fade .modal-dialog{-webkit-transform:translate(0,-25%);-ms-transform:translate(0,-25%);transform:translate(0,-25%);-webkit-transition:-webkit-transform .3s ease-out;-moz-transition:-moz-transform .3s ease-out;-o-transition:-o-transform .3s ease-out;transition:transform .3s ease-out}.modal.in .modal-dialog{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0)}.modal-dialog{z-index:1050;width:auto;padding:10px;margin-right:auto;margin-left:auto}.modal-content{position:relative;background-color:#fff;border:1px solid #999;border:1px solid rgba(0,0,0,0.2);border-radius:6px;outline:0;-webkit-box-shadow:0 3px 9px rgba(0,0,0,0.5);box-shadow:0 3px 9px rgba(0,0,0,0.5);background-clip:padding-box}.modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1030;background-color:#000}.modal-backdrop.fade{opacity:0;filter:alpha(opacity=0)}.modal-backdrop.in{opacity:.5;filter:alpha(opacity=50)}.modal-header{min-height:16.428571429px;padding:15px;border-bottom:1px solid #e5e5e5}.modal-header .close{margin-top:-2px}.modal-title{margin:0;line-height:1.428571429}.modal-body{position:relative;padding:20px}.modal-footer{padding:19px 20px 20px;margin-top:15px;text-align:right;border-top:1px solid #e5e5e5}.modal-footer:before,.modal-footer:after{display:table;content:" "}.modal-footer:after{clear:both}.modal-footer:before,.modal-footer:after{display:table;content:" "}.modal-footer:after{clear:both}.modal-footer .btn+.btn{margin-bottom:0;margin-left:5px}.modal-footer .btn-group .btn+.btn{margin-left:-1px}.modal-footer .btn-block+.btn-block{margin-left:0}@media screen and (min-width:768px){.modal-dialog{right:auto;left:50%;width:600px;padding-top:30px;padding-bottom:30px}.modal-content{-webkit-box-shadow:0 5px 15px rgba(0,0,0,0.5);box-shadow:0 5px 15px rgba(0,0,0,0.5)}}.tooltip{position:absolute;z-index:1030;display:block;font-size:12px;line-height:1.4;opacity:0;filter:alpha(opacity=0);visibility:visible}.tooltip.in{opacity:.9;filter:alpha(opacity=90)}.tooltip.top{padding:5px 0;margin-top:-3px}.tooltip.right{padding:0 5px;margin-left:3px}.tooltip.bottom{padding:5px 0;margin-top:3px}.tooltip.left{padding:0 5px;margin-left:-3px}.tooltip-inner{max-width:200px;padding:3px 8px;color:#fff;text-align:center;text-decoration:none;background-color:#000;border-radius:4px}.tooltip-arrow{position:absolute;width:0;height:0;border-color:transparent;border-style:solid}.tooltip.top .tooltip-arrow{bottom:0;left:50%;margin-left:-5px;border-top-color:#000;border-width:5px 5px 0}.tooltip.top-left .tooltip-arrow{bottom:0;left:5px;border-top-color:#000;border-width:5px 5px 0}.tooltip.top-right .tooltip-arrow{right:5px;bottom:0;border-top-color:#000;border-width:5px 5px 0}.tooltip.right .tooltip-arrow{top:50%;left:0;margin-top:-5px;border-right-color:#000;border-width:5px 5px 5px 0}.tooltip.left .tooltip-arrow{top:50%;right:0;margin-top:-5px;border-left-color:#000;border-width:5px 0 5px 5px}.tooltip.bottom .tooltip-arrow{top:0;left:50%;margin-left:-5px;border-bottom-color:#000;border-width:0 5px 5px}.tooltip.bottom-left .tooltip-arrow{top:0;left:5px;border-bottom-color:#000;border-width:0 5px 5px}.tooltip.bottom-right .tooltip-arrow{top:0;right:5px;border-bottom-color:#000;border-width:0 5px 5px}.popover{position:absolute;top:0;left:0;z-index:1010;display:none;max-width:276px;padding:1px;text-align:left;white-space:normal;background-color:#fff;border:1px solid #ccc;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 5px 10px rgba(0,0,0,0.2);box-shadow:0 5px 10px rgba(0,0,0,0.2);background-clip:padding-box}.popover.top{margin-top:-10px}.popover.right{margin-left:10px}.popover.bottom{margin-top:10px}.popover.left{margin-left:-10px}.popover-title{padding:8px 14px;margin:0;font-size:14px;font-weight:normal;line-height:18px;background-color:#f7f7f7;border-bottom:1px solid #ebebeb;border-radius:5px 5px 0 0}.popover-content{padding:9px 14px}.popover .arrow,.popover .arrow:after{position:absolute;display:block;width:0;height:0;border-color:transparent;border-style:solid}.popover .arrow{border-width:11px}.popover .arrow:after{border-width:10px;content:""}.popover.top .arrow{bottom:-11px;left:50%;margin-left:-11px;border-top-color:#999;border-top-color:rgba(0,0,0,0.25);border-bottom-width:0}.popover.top .arrow:after{bottom:1px;margin-left:-10px;border-top-color:#fff;border-bottom-width:0;content:" "}.popover.right .arrow{top:50%;left:-11px;margin-top:-11px;border-right-color:#999;border-right-color:rgba(0,0,0,0.25);border-left-width:0}.popover.right .arrow:after{bottom:-10px;left:1px;border-right-color:#fff;border-left-width:0;content:" "}.popover.bottom .arrow{top:-11px;left:50%;margin-left:-11px;border-bottom-color:#999;border-bottom-color:rgba(0,0,0,0.25);border-top-width:0}.popover.bottom .arrow:after{top:1px;margin-left:-10px;border-bottom-color:#fff;border-top-width:0;content:" "}.popover.left .arrow{top:50%;right:-11px;margin-top:-11px;border-left-color:#999;border-left-color:rgba(0,0,0,0.25);border-right-width:0}.popover.left .arrow:after{right:1px;bottom:-10px;border-left-color:#fff;border-right-width:0;content:" "}.carousel{position:relative}.carousel-inner{position:relative;width:100%;overflow:hidden}.carousel-inner>.item{position:relative;display:none;-webkit-transition:.6s ease-in-out left;transition:.6s ease-in-out left}.carousel-inner>.item>img,.carousel-inner>.item>a>img{display:block;height:auto;max-width:100%;line-height:1}.carousel-inner>.active,.carousel-inner>.next,.carousel-inner>.prev{display:block}.carousel-inner>.active{left:0}.carousel-inner>.next,.carousel-inner>.prev{position:absolute;top:0;width:100%}.carousel-inner>.next{left:100%}.carousel-inner>.prev{left:-100%}.carousel-inner>.next.left,.carousel-inner>.prev.right{left:0}.carousel-inner>.active.left{left:-100%}.carousel-inner>.active.right{left:100%}.carousel-control{position:absolute;top:0;bottom:0;left:0;width:15%;font-size:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6);opacity:.5;filter:alpha(opacity=50)}.carousel-control.left{background-image:-webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.5)),to(rgba(0,0,0,0.0001)));background-image:-webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.5) 0),color-stop(rgba(0,0,0,0.0001) 100%));background-image:-moz-linear-gradient(left,rgba(0,0,0,0.5) 0,rgba(0,0,0,0.0001) 100%);background-image:linear-gradient(to right,rgba(0,0,0,0.5) 0,rgba(0,0,0,0.0001) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000',endColorstr='#00000000',GradientType=1)}.carousel-control.right{right:0;left:auto;background-image:-webkit-gradient(linear,0 top,100% top,from(rgba(0,0,0,0.0001)),to(rgba(0,0,0,0.5)));background-image:-webkit-linear-gradient(left,color-stop(rgba(0,0,0,0.0001) 0),color-stop(rgba(0,0,0,0.5) 100%));background-image:-moz-linear-gradient(left,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.5) 100%);background-image:linear-gradient(to right,rgba(0,0,0,0.0001) 0,rgba(0,0,0,0.5) 100%);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000',endColorstr='#80000000',GradientType=1)}.carousel-control:hover,.carousel-control:focus{color:#fff;text-decoration:none;opacity:.9;filter:alpha(opacity=90)}.carousel-control .icon-prev,.carousel-control .icon-next,.carousel-control .glyphicon-chevron-left,.carousel-control .glyphicon-chevron-right{position:absolute;top:50%;left:50%;z-index:5;display:inline-block}.carousel-control .icon-prev,.carousel-control .icon-next{width:20px;height:20px;margin-top:-10px;margin-left:-10px;font-family:serif}.carousel-control .icon-prev:before{content:'\2039'}.carousel-control .icon-next:before{content:'\203a'}.carousel-indicators{position:absolute;bottom:10px;left:50%;z-index:15;width:60%;padding-left:0;margin-left:-30%;text-align:center;list-style:none}.carousel-indicators li{display:inline-block;width:10px;height:10px;margin:1px;text-indent:-999px;cursor:pointer;border:1px solid #fff;border-radius:10px}.carousel-indicators .active{width:12px;height:12px;margin:0;background-color:#fff}.carousel-caption{position:absolute;right:15%;bottom:20px;left:15%;z-index:10;padding-top:20px;padding-bottom:20px;color:#fff;text-align:center;text-shadow:0 1px 2px rgba(0,0,0,0.6)}.carousel-caption .btn{text-shadow:none}@media screen and (min-width:768px){.carousel-control .icon-prev,.carousel-control .icon-next{width:30px;height:30px;margin-top:-15px;margin-left:-15px;font-size:30px}.carousel-caption{right:20%;left:20%;padding-bottom:30px}.carousel-indicators{bottom:20px}}.clearfix:before,.clearfix:after{display:table;content:" "}.clearfix:after{clear:both}.pull-right{float:right!important}.pull-left{float:left!important}.hide{display:none!important}.show{display:block!important}.invisible{visibility:hidden}.text-hide{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}.affix{position:fixed}@-ms-viewport{width:device-width}@media screen and (max-width:400px){@-ms-viewport{width:320px}}.hidden{display:none!important;visibility:hidden!important}.visible-xs{display:none!important}tr.visible-xs{display:none!important}th.visible-xs,td.visible-xs{display:none!important}@media(max-width:767px){.visible-xs{display:block!important}tr.visible-xs{display:table-row!important}th.visible-xs,td.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-xs.visible-sm{display:block!important}tr.visible-xs.visible-sm{display:table-row!important}th.visible-xs.visible-sm,td.visible-xs.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-xs.visible-md{display:block!important}tr.visible-xs.visible-md{display:table-row!important}th.visible-xs.visible-md,td.visible-xs.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-xs.visible-lg{display:block!important}tr.visible-xs.visible-lg{display:table-row!important}th.visible-xs.visible-lg,td.visible-xs.visible-lg{display:table-cell!important}}.visible-sm{display:none!important}tr.visible-sm{display:none!important}th.visible-sm,td.visible-sm{display:none!important}@media(max-width:767px){.visible-sm.visible-xs{display:block!important}tr.visible-sm.visible-xs{display:table-row!important}th.visible-sm.visible-xs,td.visible-sm.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-sm{display:block!important}tr.visible-sm{display:table-row!important}th.visible-sm,td.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-sm.visible-md{display:block!important}tr.visible-sm.visible-md{display:table-row!important}th.visible-sm.visible-md,td.visible-sm.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-sm.visible-lg{display:block!important}tr.visible-sm.visible-lg{display:table-row!important}th.visible-sm.visible-lg,td.visible-sm.visible-lg{display:table-cell!important}}.visible-md{display:none!important}tr.visible-md{display:none!important}th.visible-md,td.visible-md{display:none!important}@media(max-width:767px){.visible-md.visible-xs{display:block!important}tr.visible-md.visible-xs{display:table-row!important}th.visible-md.visible-xs,td.visible-md.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-md.visible-sm{display:block!important}tr.visible-md.visible-sm{display:table-row!important}th.visible-md.visible-sm,td.visible-md.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-md{display:block!important}tr.visible-md{display:table-row!important}th.visible-md,td.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-md.visible-lg{display:block!important}tr.visible-md.visible-lg{display:table-row!important}th.visible-md.visible-lg,td.visible-md.visible-lg{display:table-cell!important}}.visible-lg{display:none!important}tr.visible-lg{display:none!important}th.visible-lg,td.visible-lg{display:none!important}@media(max-width:767px){.visible-lg.visible-xs{display:block!important}tr.visible-lg.visible-xs{display:table-row!important}th.visible-lg.visible-xs,td.visible-lg.visible-xs{display:table-cell!important}}@media(min-width:768px) and (max-width:991px){.visible-lg.visible-sm{display:block!important}tr.visible-lg.visible-sm{display:table-row!important}th.visible-lg.visible-sm,td.visible-lg.visible-sm{display:table-cell!important}}@media(min-width:992px) and (max-width:1199px){.visible-lg.visible-md{display:block!important}tr.visible-lg.visible-md{display:table-row!important}th.visible-lg.visible-md,td.visible-lg.visible-md{display:table-cell!important}}@media(min-width:1200px){.visible-lg{display:block!important}tr.visible-lg{display:table-row!important}th.visible-lg,td.visible-lg{display:table-cell!important}}.hidden-xs{display:block!important}tr.hidden-xs{display:table-row!important}th.hidden-xs,td.hidden-xs{display:table-cell!important}@media(max-width:767px){.hidden-xs{display:none!important}tr.hidden-xs{display:none!important}th.hidden-xs,td.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-xs.hidden-sm{display:none!important}tr.hidden-xs.hidden-sm{display:none!important}th.hidden-xs.hidden-sm,td.hidden-xs.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-xs.hidden-md{display:none!important}tr.hidden-xs.hidden-md{display:none!important}th.hidden-xs.hidden-md,td.hidden-xs.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-xs.hidden-lg{display:none!important}tr.hidden-xs.hidden-lg{display:none!important}th.hidden-xs.hidden-lg,td.hidden-xs.hidden-lg{display:none!important}}.hidden-sm{display:block!important}tr.hidden-sm{display:table-row!important}th.hidden-sm,td.hidden-sm{display:table-cell!important}@media(max-width:767px){.hidden-sm.hidden-xs{display:none!important}tr.hidden-sm.hidden-xs{display:none!important}th.hidden-sm.hidden-xs,td.hidden-sm.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-sm{display:none!important}tr.hidden-sm{display:none!important}th.hidden-sm,td.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-sm.hidden-md{display:none!important}tr.hidden-sm.hidden-md{display:none!important}th.hidden-sm.hidden-md,td.hidden-sm.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-sm.hidden-lg{display:none!important}tr.hidden-sm.hidden-lg{display:none!important}th.hidden-sm.hidden-lg,td.hidden-sm.hidden-lg{display:none!important}}.hidden-md{display:block!important}tr.hidden-md{display:table-row!important}th.hidden-md,td.hidden-md{display:table-cell!important}@media(max-width:767px){.hidden-md.hidden-xs{display:none!important}tr.hidden-md.hidden-xs{display:none!important}th.hidden-md.hidden-xs,td.hidden-md.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-md.hidden-sm{display:none!important}tr.hidden-md.hidden-sm{display:none!important}th.hidden-md.hidden-sm,td.hidden-md.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-md{display:none!important}tr.hidden-md{display:none!important}th.hidden-md,td.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-md.hidden-lg{display:none!important}tr.hidden-md.hidden-lg{display:none!important}th.hidden-md.hidden-lg,td.hidden-md.hidden-lg{display:none!important}}.hidden-lg{display:block!important}tr.hidden-lg{display:table-row!important}th.hidden-lg,td.hidden-lg{display:table-cell!important}@media(max-width:767px){.hidden-lg.hidden-xs{display:none!important}tr.hidden-lg.hidden-xs{display:none!important}th.hidden-lg.hidden-xs,td.hidden-lg.hidden-xs{display:none!important}}@media(min-width:768px) and (max-width:991px){.hidden-lg.hidden-sm{display:none!important}tr.hidden-lg.hidden-sm{display:none!important}th.hidden-lg.hidden-sm,td.hidden-lg.hidden-sm{display:none!important}}@media(min-width:992px) and (max-width:1199px){.hidden-lg.hidden-md{display:none!important}tr.hidden-lg.hidden-md{display:none!important}th.hidden-lg.hidden-md,td.hidden-lg.hidden-md{display:none!important}}@media(min-width:1200px){.hidden-lg{display:none!important}tr.hidden-lg{display:none!important}th.hidden-lg,td.hidden-lg{display:none!important}}.visible-print{display:none!important}tr.visible-print{display:none!important}th.visible-print,td.visible-print{display:none!important}@media print{.visible-print{display:block!important}tr.visible-print{display:table-row!important}th.visible-print,td.visible-print{display:table-cell!important}.hidden-print{display:none!important}tr.hidden-print{display:none!important}th.hidden-print,td.hidden-print{display:none!important}}
 */
-body {
-  background-color: #eee;
-}
 
-.form-signin {
-  max-width: 330px;
-  padding: 0px, 15px, 15px, 15px;
-  margin: 0 auto;
+body {
+  background-color: #FFF;
+  padding-top: 0px!important;
+  padding-bottom: 0px!important;
 }
-.form-signin .form-signin-heading,
-.form-signin .checkbox {
-  margin-bottom: 10px;
-}
-.form-signin .checkbox {
-  font-weight: normal;
-}
-.form-signin .form-control {
-  position: relative;
-  font-size: 16px;
-  height: auto;
-  padding: 10px;
-  -webkit-box-sizing: border-box;
-     -moz-box-sizing: border-box;
-          box-sizing: border-box;
-}
-.form-signin .form-control:focus {
-  z-index: 2;
-}
-.form-signin input[type="text"] {
-  margin-bottom: -1px;
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.form-signin input[type="password"] {
-  margin-bottom: 10px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-/*floatlabel.css*/
 * {
   box-sizing: border-box;
 }
 
-.form-signin input[type="text"] {
-    margin: auto;
-    -webkit-border-radius: 4px;
-    -moz-border-radius: 4px;
-    border-radius: 4px;
+label {
+  display: inline-block;
+  margin-bottom: 5px;
+  margin-top: 4px;
+  font-weight: normal;
+  color: gray;
 }
-form.go-bottom > div {
+
+/* bootstrap override */
+.nav-tabs>li{
+  margin: 2px;
+  border: solid 2px white!important;
+}
+.nav-tabs>li>a{
+  border-radius: 0!important;
+}
+.nav-tabs>li>a{
+  background-color: #F5F5F5!important;
+  border: solid 2px white!important;
+}
+.nav-tabs>li.active, .nav-tabs>li.active:hover, .nav-tabs>li.active:focus{
+  border: solid 2px #71D5DA!important;
+  box-shadow: 0px 2px 2px #ddd;
+}
+.nav-tabs>li:hover{
+  box-shadow: 0px 2px 2px #ddd;
+}
+.nav-tabs{
+  border: none;
+}
+.nav-tabs>li>a{
+  margin: 0;
+}
+.row{
+  margin-right: 0px!important;
+  margin-left: 0px!important;
+}
+.nopadleft{
+  padding-left: 0px;
+}
+.nopadright{
+  padding-right: 0px;
+}
+.nav-tabs > li, .nav-pills > li {
+  float: none;
+  display: inline-block;
+  *display: inline;
+  /* ie7 fix */
+  zoom: 1;
+  /* hasLayout ie7 trigger */
+}
+.nav-tabs, .nav-pills {
+  text-align: center;
+}
+ul li {
+  width: 90px;
+}
+ul li img {
+  width: 50px;
+}
+
+.credit_card_tab img{
+  width: 23px;
+}
+.nav-tabs>li.active, .nav-tabs>li.active:hover, .nav-tabs>li.active:focus{
+  border: solid 2px #71D5DA!important;
+  box-shadow: 0px 2px 2px #ddd;
+}
+
+
+input:-webkit-autofill {
+    color: #000 !important;
+}
+
+/*
+ Mondido payment
+*/
+#paymentArea {
+  height: auto;
   position: relative;
-  overflow: hidden;
-}
-form.go-bottom input.form-control, form.go-bottom textarea {
-  width: 100%;
-  background: none;
-  position: relative;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  padding: 8px 12px;
-  outline: 0;
+  margin: 0 auto;
 }
 
-form.go-bottom input.form-control:disabled {
-  background: white;
+.logo {
+  height: 40px;
+  filter: url("data:image/svg+xml;utf8,&lt;svg xmlns=\'http://www.w3.org/2000/svg\'&gt;&lt;filter id=\'grayscale\'&gt;&lt;feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/&gt;&lt;/filter&gt;&lt;/svg&gt;#grayscale"); /* Firefox 10+, Firefox on Android */
+  filter: gray; /* IE6-9 */
+  -webkit-filter: grayscale(100%); /* Chrome 19+, Safari 6+, Safari 6+ iOS */
 }
 
-form.go-bottom input.form-control:valid, form.go-bottom textarea.form-control:valid {
-  background: white;
-}
-form.go-bottom input.form-control:focus, form.go-bottom textarea:focus {
-  border-color: #f06d06;
-  padding: 6px!important;
+.logo:hover{
+  filter:none;
+  -webkit-filter: none;
 }
 
-form.go-bottom input.form-control:focus + label, form.go-bottom textarea:focus + label {
-  color: #333;
-  font-size: 70%;
-  padding: 1px 16px;
-  z-index: 2;
-  text-transform: uppercase;
+.semi{
+  border: none!important;
+  box-shadow: none!important;
 }
-form.go-bottom label {
-  transition: background 0.2s, color 0.2s, top 0.2s, bottom 0.2s, right 0.2s, left 0.2s;
-  position: absolute;
-  color: #999;
-  padding: 7px 6px;
-  text-align: left;
-  margin-top: -20%;
+
+.invalid, .not-valid {
+  background-color: white;
+  border: 1px solid #F00 !important;
 }
-form.go-bottom textarea {
+.valid {
+  background-color: white;
+  border: 1px solid #5cb85c !important;
+}
+input:placeholder-shown {
+    border: 1px solid #71d5da; /* Red border only if the input is empty */
+}
+
+.active {
   display: block;
-  resize: vertical;
+}
+.hidden {
+  display: none;
+}
+#loading {
+  text-align: center;
+  margin-top: 20px;
+}
+#errors {
+  display: none;
+}
+#paybtn, #paybtn-cc {
+  margin: 20px 0;
+}
+#comodo_secure {
+  margin-top: 15px;
+}
+.comodotext {
+  font-size: 11px;
 }
 
-form.go-bottom input.form-control, form.go-bottom textarea {
-    transition: padding 0.2s, color 0.2s, top 0.2s, bottom 0.2s, right 0.2s, left 0.2s;
-    padding: 12px 12px 12px 12px!important;
-}
-form.go-bottom input.form-control:focus, form.go-bottom textarea:focus {
-    transition: padding 0.2s, color 0.2s, top 0.2s, bottom 0.2s, right 0.2s, left 0.2s;
-    padding: 4px 12px 20px 12px!important;
-}
-form.go-bottom label {
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-}
-form.go-bottom input.form-control:focus + label, form.go-bottom textarea:focus + label {
-  top: 100%;
-  margin-top: -16px;
+
+#mondidoPaymentTab .fa {
+  font-size: 20px;
 }
 
-form.go-right label {
-  top: 2px;
-  right: 100%;
-  width: 100%;
-  margin-right: -100%;
-  bottom: 2px;
-}
-form.go-right input.form-control:focus + label, form.go-right textarea:focus + label {
-  right: 0;
-  margin-right: 0;
-  width: 40%;
-  padding-top: 5px;
+.btn-invalid {
+  color: #fff;
+  background-color: #dbdcdb;
+  border-color: #b5b5b5;
 }
 
-/*mondido*/
-    body {
-    padding-top: 0px!important;
-    padding-bottom: 0px!important;
-    }
-    #main_area {
-    height: auto;
-    position: relative;
-    margin: 0 auto;
-    }
-    .logo {
-    height: 40px;
-
-    filter: url("data:image/svg+xml;utf8,&lt;svg xmlns=\'http://www.w3.org/2000/svg\'&gt;&lt;filter id=\'grayscale\'&gt;&lt;feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/&gt;&lt;/filter&gt;&lt;/svg&gt;#grayscale"); /* Firefox 10+, Firefox on Android */
-    filter: gray; /* IE6-9 */
-    -webkit-filter: grayscale(100%); /* Chrome 19+, Safari 6+, Safari 6+ iOS */
-    }
-
-    .logo:hover{
-      filter:none;
-      -webkit-filter: none;
-    }
-
-
-    .content-white {
-    background-color: white;
-    }
-    select {
-    font-size: 16px!important;
-    margin-right: 10px;
-    padding: 8px!important;
-    }
-    label {
-    margin-top: 10px;
-    }
-    .semi{
-        border: none!important;
-        box-shadow: none!important;
-    }
-
-    .invalid, .not-valid {
-    background-color: white;
-    border: 1px solid #F00 !important;
-    }
-    .valid {
-    background-color: white;
-    border: 1px solid #5cb85c !important;
-    }
-    .footer {
-    color: #aaa;
-    }
-    .card_number_div {
-    position: relative;
-    width: 100%;
-    }
-    .cards {
-    height: 32px;
-    top: 10.5%;
-    right: 2.5%;
-    z-index: 9999;
-    width: 51px;
-    height: 32px;
-    position: absolute;
-    display: none;
-    }
-    .maestro {
-    background-position: -153px 0px;
-    }
-    .mastercard {
-    background-position: -102px 0px;
-    }
-    .electron {
-    background-position: -51px 0px;
-    }
-    .visa {
-    background-position: 0px 0px;
-    }
-    .discover {
-    background-position: -204px 0px;
-    }
-    .amex {
-    background-position: -255px 0px;
-    }
-    .not_accepted{
-        background-position-y: -32px;
-    }
-    .active {
-    display: block;
-    }
-    .hidden {
-    display: none;
-    }
-    #loading {
-    text-align: center;
-    margin-top: 20px;
-    }
-    #errors {
-    display: none;
-    }
-    #paybtn, #paybtn-cc {
-    margin: 20px 0;
-    }
-    #comodo_secure {
-    margin-top: 15px;
-    }
-    .comodotext {
-    margin-top: 15px;
-    font-size: 11px;
-    }
-    .nav-tabs >
-    li, .nav-pills >
-    li {
-    float: none;
-    display: inline-block;
-    *display: inline;
-    /* ie7 fix */
-    zoom: 1;
-    /* hasLayout ie7 trigger */
-    }
-    .nav-tabs, .nav-pills {
-    text-align: center;
-    }
-    ul li {
-        width: 90px;
-    }
-    ul li img {
-    width: 50px;
-    }
-    #myTab .fa {
-    font-size: 20px;
-    }
-    @media screen {
-        .has-error input {
-            border-width: 2px;
-        }
-        .validation.text-danger:after {
-            content: 'Validation failed';
-        }
-        .validation.text-success:after {
-            content: 'Validation passed';
-        }
-        .col-xs-6, .col-xs-12 {
-            padding-left: 2px!important;
-            padding-right: 2px!important;
-        }
-        .header {
-            padding-top: 10px!important;
-            margin: 0 auto;
-        }
-    }
-    .swish-img{
-        height:85px;
-        margin-top: 10px;
-        margin-bottom: 10px;
-    }
-    .paypal-img{
-        height:50px;
-        margin: 10px 0;
-    }
-
-
-    #invoice_foot p{
-        text-align: left;
-    }
-    #invoice_foot img{
-        margin-top:10px;
-        margin-bottom:10px;
-        width: 150px;
-    }
-    #paybtn-paypal{
-        margin-bottom:100px;
-    }
-    .logoRow{
-        text-align:center;
-        background-color: #eee;
-    }
-    .choose{
-        margin: 10px 0px;
-    }
-    .grayc {
-        background: white; /* For browsers that do not support gradients */
-        background: -webkit-radial-gradient(white, #f5f5f5); /* Safari 5.1 to 6.0 */
-        background: -o-radial-gradient(white, #f5f5f5); /* For Opera 11.6 to 12.0 */
-        background: -moz-radial-gradient(white, #f5f5f5); /* For Firefox 3.6 to 15 */
-        background: radial-gradient(white, #f5f5f5); /* Standard syntax (must be last) */
-    }
-    .container{
-        padding-bottom:10px;
-    }
-    .spacer{
-        margin-bottom: 15px;
-    }
-    .amount{
-        font-size: 20px;
-    }
-
-    /* bootstrap override */
-    .nav-tabs>li{
-        margin: 2px;
-        border: solid 2px white!important;
-    }
-    .nav-tabs>li>a{
-        border-radius: 0!important;
-    }
-    .nav-tabs>li>a{
-        background-color: #F5F5F5!important;
-        border: solid 2px white!important;
-    }
-    .nav-tabs>li.active, .nav-tabs>li.active:hover, .nav-tabs>li.active:focus{
-        border: solid 2px #71D5DA!important;
-            box-shadow: 0px 2px 2px #ddd;
-    }
-    .nav-tabs>li:hover{
-            box-shadow: 0px 2px 2px #ddd;
-    }
-    .nav-tabs{
-        border: none;
-    }
-    .nav-tabs>li>a{
-        margin: 0;
-    }
-    .row{
-        margin-right: 0px!important;
-        margin-left: 0px!important;
-    }
-    .nopadleft{
-        padding-left: 0px;
-    }
-    .nopadright{
-        padding-right: 0px;
-    }
-
-@media (max-device-width: 414px) {
-    ul li {
-        width: 72px;
-    }
-    ul li img{
-        width:40px;
-    }
-    .nav>li>a{
-            padding: 10px 0px;
-    }
+.small_tab_text{
+  color: #777777;
+}
+.small_tab_text a{
+  color: #777777;
 }
 
-    @media (max-device-width: 376px) {
-    ul li {
-        width: 64px;
-        margin: 2px;
-        border: none;
-    }
-    ul li img{
-        width:42px;
-    }
-    .nav>li>a{
-            padding: 10px 0px;
-    }
+.logoRow{
+  text-align:center;
+  background-color: #eee;
 }
-                @media (max-device-width: 360px) {
-    ul li {
-        width: 54px;
-        margin: 2px;
-        border: none;
-    }
-    ul li img{
-        width:43px;
-    }
-    .nav>li>a{
-            padding: 6px 0px;
-    }
+.choose{
+  margin: 5px 0px;
+}
+.grayc {
+  background: white; /* For browsers that do not support gradients */
+  background: -webkit-radial-gradient(white, #f5f5f5); /* Safari 5.1 to 6.0 */
+  background: -o-radial-gradient(white, #f5f5f5); /* For Opera 11.6 to 12.0 */
+  background: -moz-radial-gradient(white, #f5f5f5); /* For Firefox 3.6 to 15 */
+  background: radial-gradient(white, #f5f5f5); /* Standard syntax (must be last) */
+}
+.container{
+  padding-bottom:10px;
+}
+.spacer{
+  margin-bottom: 15px;
+}
+.amount{
+  font-size: 20px;
 }
 
-        @media (max-device-width: 320px) {
-    ul li {
-        width: 54px;
-        margin: 2px;
-        border: none;
-    }
-    ul li img{
-        width:43px;
-    }
-    .nav>li>a{
-            padding: 6px 0px;
-    }
+/* Card  */
+.card_number_div{
+  position: relative;
+  width:100%;
+}
+.cards{
+  background: url(https://s3-eu-west-1.amazonaws.com/mondido-dev/tmp/card_logos.png);
+  height:32px;
+
+  top:10.5%;
+  right:2.5%;
+  z-index: 9999;
+
+  width: 51px;
+  height: 32px;
+  position: absolute;
+
+  display:none;
+}
+
+.maestro {
+  background-position: -153px 0px;
+}
+.mastercard {
+  background-position: -102px 0px;
+}
+.electron {
+  background-position: -51px 0px;
+}
+.visa {
+  background-position: 0px 0px;
+}
+.discover {
+  background-position: -204px 0px;
+}
+.amex {
+  background-position: -255px 0px;
+}
+.not_accepted{
+  background-position-y: -32px;
+}
+
+/* Invoice */
+#invoice_foot p{
+  text-align: left;
+}
+#invoice_foot img{
+  margin-top:10px;
+  margin-bottom:10px;
+  width: 150px;
+}
+
+/* Swish */
+.swish-img{
+  height:85px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+/* PayPal */
+#paybtn-paypal{
+  margin-bottom:100px;
+}
+.paypal-img{
+  height:50px;
+  margin: 10px 0;
+}
+
+
+/* MasterPass */
+.masterpass_img_tab{
+  height: 70%;
+  width: 70%;
+}
+.masterpass_small_text{
+  margin-left: -5px;
+}
+
+
+/* langswitch */
+#languages{
+  text-align: center;
 }
 .langswitch{
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    text-align: center;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  text-align: center;
 }
 .langswitch>li{
-     display: inline;
-     width: auto;
+  display: inline;
+  width: auto;
 }
 .langswitch>li>a {
-    display: inline-block;
-    color: gray;
-    text-align: center;
-    padding: 3px 5px;
-    text-decoration: none;
+  display: inline-block;
+  color: gray;
+  text-align: center;
+  padding: 3px 5px;
+  text-decoration: none;
 }
 .langswitch>li>a:hover, .langswitch>li>a.active {
-    background-color: #ddd;
+  background-color: #ddd;
 }
 
-.footer .card-img, #comodo_secure{
-    height: 30px;
-    margin-bottom: 10px;
 
-        filter: url("data:image/svg+xml;utf8,&lt;svg xmlns=\'http://www.w3.org/2000/svg\'&gt;&lt;filter id=\'grayscale\'&gt;&lt;feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/&gt;&lt;/filter&gt;&lt;/svg&gt;#grayscale"); /* Firefox 10+, Firefox on Android */
-    filter: gray; /* IE6-9 */
-    -webkit-filter: grayscale(100%); /* Chrome 19+, Safari 6+, Safari 6+ iOS */
-}
-.footer .card-img:hover, #comodo_secure{
-    filter:none;
-    -webkit-filter: none;
-}
 
 .cards.not_accepted .arrow_box {
-     visibility: visible;
+  visibility: visible;
 }
 
 .arrow_box {
-    color: white;
-    font-size: 10px;
-    text-transform: uppercase;
-    padding: 10px;
-    width: 145px;
-    height: 54px;
-    border-radius: 4px;
-    box-shadow: 0px 2px 2px #aaa;
-    visibility: hidden;
+  color: white;
+  font-size: 10px;
+  text-transform: uppercase;
+  padding: 10px;
+  width: 145px;
+  height: 54px;
+  border-radius: 4px;
+  box-shadow: 0px 2px 2px #aaa;
+  visibility: hidden;
 
-    /* Position the tooltip */
-    position: absolute;
-    z-index: 1;
-    top: -13px;
-    left: 130%;
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  top: -13px;
+  left: 130%;
 
-	position: relative;
-	background: #d58888;
-	border: 2px solid #a00;
+  position: relative;
+  background: #d58888;
+  border: 2px solid #a00;
 }
 .arrow_box:after, .arrow_box:before {
-	right: 100%;
-	top: 50%;
-	border: solid transparent;
-	content: " ";
-	height: 0;
-	width: 0;
-	position: absolute;
-	pointer-events: none;
+  right: 100%;
+  top: 50%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
 }
 
 .arrow_box:after {
-	border-color: rgba(213, 136, 136, 0);
-	border-right-color: #d58888;
-	border-width: 14px;
-	margin-top: -13px;
+  border-color: rgba(213, 136, 136, 0);
+  border-right-color: #d58888;
+  border-width: 14px;
+  margin-top: -13px;
 }
 .arrow_box:before {
-	border-color: rgba(83, 96, 105, 0);
-	border-right-color: #a00;
-	border-width: 17px;
-	margin-top: -16px;
+  border-color: rgba(83, 96, 105, 0);
+  border-right-color: #a00;
+  border-width: 17px;
+  margin-top: -16px;
 }
 
-#languages{
-    text-align: center;
-}
 
-.nav-tabs>li.active, .nav-tabs>li.active:hover, .nav-tabs>li.active:focus{
-    border: solid 2px #71D5DA!important;
-    box-shadow: 0px 2px 2px #ddd;
-}
+
+
 
 .btn-sm{
- color: #FFF;
+  color: #FFF;
 }
 
 .btn-sm, .btn-xs{
@@ -544,103 +374,449 @@ form.go-right input.form-control:focus + label, form.go-right textarea:focus + l
 }
 
 .btn-primary:hover, .btn-primary:focus, .btn-primary:active, .btn-primary.active, .open .dropdown-toggle.btn-primary {
-    color: #fff;
-    background-color: #000;
-    border-color: #000;
+  color: #fff;
+  background-color: #000;
+  border-color: #000;
 }
 
-span.bigcheck-target {
-    position: initial;
-    font-weight: 400;
-    font-size: 4em; /* set this to whatever size you want */
-    font-family: FontAwesome; /* use an icon font for the checkbox */    
+.footer .card-img, #comodo_secure{
+  height: 30px;
+  margin-bottom: 10px;
+    color: #aaa;
+
+    filter: url("data:image/svg+xml;utf8,&lt;svg xmlns=\'http://www.w3.org/2000/svg\'&gt;&lt;filter id=\'grayscale\'&gt;&lt;feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/&gt;&lt;/filter&gt;&lt;/svg&gt;#grayscale"); /* Firefox 10+, Firefox on Android */
+  filter: gray; /* IE6-9 */
+  -webkit-filter: grayscale(100%); /* Chrome 19+, Safari 6+, Safari 6+ iOS */
 }
-
-input[type='checkbox'].bigcheck {     
-    position: relative;
-    left: -999em; /* hide the real checkbox */
+.footer .card-img:hover, #comodo_secure{
+  filter:none;
+  -webkit-filter: none;
 }
-
-input[type='checkbox'].bigcheck + span.bigcheck-target:after {
-    content: "\f096"; /* In fontawesome, is an open square (fa-square-o) */
-    color: #71d5da;
-}
-
-input[type='checkbox'].bigcheck:checked + span.bigcheck-target:after {
-    content: "\f046"; /* fontawesome checked box (fa-check-square-o) */
-   position: initial;
-   color: #5cb85c;
-}
-
-
-input:focus {
-  background-color: white;
-  border: 1px solid #71d5da !important;
-}
-
 #poweredBy{
-    color: gray;
+  color: gray;
 }
-
 .m-layout-logo{
   margin: 4px;
   max-width: 300px;
   max-height: 120px;
 }
 
+/*
 
-/* 
-  spinner
+spinner
+
 */
-.spinner {
+span.bigcheck-target {
+  position: initial;
+  font-weight: 400;
+  font-size: 4em; /* set this to whatever size you want */
+  font-family: FontAwesome; /* use an icon font for the checkbox */
+  margin-top: -10px;
+
+}
+
+.load-center{
+  position: fixed;
+  top: 40%;
+  left: 50%;
+  /* bring your own prefixes */
+  transform: translate(-40%, -50%);
+}
+
+.sk-circle {
   margin: 100px auto;
-  width: 50px;
+  width: 40px;
   height: 40px;
-  text-align: center;
-  font-size: 10px;
+  position: relative;
 }
-
-.spinner > div {
-  background-color: #333;
+.sk-circle .sk-child {
+  width: 100%;
   height: 100%;
-  width: 6px;
-  display: inline-block;
-  
-  -webkit-animation: sk-stretchdelay 1.2s infinite ease-in-out;
-  animation: sk-stretchdelay 1.2s infinite ease-in-out;
+  position: absolute;
+  left: 0;
+  top: 0;
 }
-
-.spinner .rect2 {
+.sk-circle .sk-child:before {
+  content: '';
+  display: block;
+  margin: 0 auto;
+  width: 15%;
+  height: 15%;
+  background-color: #333;
+  border-radius: 100%;
+  -webkit-animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
+          animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
+}
+.sk-circle .sk-circle2 {
+  -webkit-transform: rotate(30deg);
+      -ms-transform: rotate(30deg);
+          transform: rotate(30deg); }
+.sk-circle .sk-circle3 {
+  -webkit-transform: rotate(60deg);
+      -ms-transform: rotate(60deg);
+          transform: rotate(60deg); }
+.sk-circle .sk-circle4 {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg); }
+.sk-circle .sk-circle5 {
+  -webkit-transform: rotate(120deg);
+      -ms-transform: rotate(120deg);
+          transform: rotate(120deg); }
+.sk-circle .sk-circle6 {
+  -webkit-transform: rotate(150deg);
+      -ms-transform: rotate(150deg);
+          transform: rotate(150deg); }
+.sk-circle .sk-circle7 {
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg); }
+.sk-circle .sk-circle8 {
+  -webkit-transform: rotate(210deg);
+      -ms-transform: rotate(210deg);
+          transform: rotate(210deg); }
+.sk-circle .sk-circle9 {
+  -webkit-transform: rotate(240deg);
+      -ms-transform: rotate(240deg);
+          transform: rotate(240deg); }
+.sk-circle .sk-circle10 {
+  -webkit-transform: rotate(270deg);
+      -ms-transform: rotate(270deg);
+          transform: rotate(270deg); }
+.sk-circle .sk-circle11 {
+  -webkit-transform: rotate(300deg);
+      -ms-transform: rotate(300deg);
+          transform: rotate(300deg); }
+.sk-circle .sk-circle12 {
+  -webkit-transform: rotate(330deg);
+      -ms-transform: rotate(330deg);
+          transform: rotate(330deg); }
+.sk-circle .sk-circle2:before {
   -webkit-animation-delay: -1.1s;
-  animation-delay: -1.1s;
-}
-
-.spinner .rect3 {
-  -webkit-animation-delay: -1.0s;
-  animation-delay: -1.0s;
-}
-
-.spinner .rect4 {
+          animation-delay: -1.1s; }
+.sk-circle .sk-circle3:before {
+  -webkit-animation-delay: -1s;
+          animation-delay: -1s; }
+.sk-circle .sk-circle4:before {
   -webkit-animation-delay: -0.9s;
-  animation-delay: -0.9s;
+          animation-delay: -0.9s; }
+.sk-circle .sk-circle5:before {
+  -webkit-animation-delay: -0.8s;
+          animation-delay: -0.8s; }
+.sk-circle .sk-circle6:before {
+  -webkit-animation-delay: -0.7s;
+          animation-delay: -0.7s; }
+.sk-circle .sk-circle7:before {
+  -webkit-animation-delay: -0.6s;
+          animation-delay: -0.6s; }
+.sk-circle .sk-circle8:before {
+  -webkit-animation-delay: -0.5s;
+          animation-delay: -0.5s; }
+.sk-circle .sk-circle9:before {
+  -webkit-animation-delay: -0.4s;
+          animation-delay: -0.4s; }
+.sk-circle .sk-circle10:before {
+  -webkit-animation-delay: -0.3s;
+          animation-delay: -0.3s; }
+.sk-circle .sk-circle11:before {
+  -webkit-animation-delay: -0.2s;
+          animation-delay: -0.2s; }
+.sk-circle .sk-circle12:before {
+  -webkit-animation-delay: -0.1s;
+          animation-delay: -0.1s; }
+
+@-webkit-keyframes sk-circleBounceDelay {
+  0%, 80%, 100% {
+    -webkit-transform: scale(0);
+            transform: scale(0);
+  } 40% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
 }
 
-.spinner .rect5 {
-  -webkit-animation-delay: -0.8s;
-  animation-delay: -0.8s;
+@keyframes sk-circleBounceDelay {
+  0%, 80%, 100% {
+    -webkit-transform: scale(0);
+            transform: scale(0);
+  } 40% {
+    -webkit-transform: scale(1);
+            transform: scale(1);
+  }
 }
+
+
+
+
+
+/* form */
+.form-signin {
+  max-width: 330px;
+  padding: 0px, 15px, 15px, 15px;
+  margin: 0 auto;
+}
+
+.form-signin .form-signin-heading,
+.form-signin .checkbox {
+  margin-bottom: 10px;
+}
+
+.form-signin .checkbox {
+  font-weight: normal;
+}
+
+.form-signin .form-control {
+  position: relative;
+  font-size: 16px;
+  height: auto;
+  padding: 10px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+      box-sizing: border-box;
+}
+
+.form-signin .form-control:focus {
+  z-index: 2;
+}
+
+.form-signin input[type="text"] {
+  margin-bottom: -1px;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.form-signin input[type="password"] {
+  margin-bottom: 10px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.form-signin input[type="text"] {
+  margin: auto;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+
+form.go-bottom > div {
+  position: relative;
+  overflow: hidden;
+}
+
+form.go-bottom input.form-control, form.go-bottom textarea {
+  width: 100%;
+  background: none;
+  position: relative;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  padding: 8px 12px;
+  outline: 0;
+}
+
+form.go-bottom input.form-control:disabled {
+  background: #e8e8e8;
+}
+
+form.go-bottom input.form-control:valid, form.go-bottom textarea.form-control:valid {
+  background: white;
+}
+
+form.go-bottom input.form-control:focus, form.go-bottom textarea:focus {
+  border-color: #f06d06;
+  padding: 6px!important;
+}
+
+form.go-bottom input.form-control:focus + label, form.go-bottom textarea:focus + label {
+  color: #333;
+  font-size: 70%;
+  padding: 1px 16px;
+  z-index: 2;
+  text-transform: uppercase;
+}
+
+form.go-bottom label {
+  transition: background 0.2s, color 0.2s, top 0.2s, bottom 0.2s, right 0.2s, left 0.2s;
+  position: absolute;
+  color: #999;
+  padding: 0px 6px;
+  text-align: left;
+}
+
+form.go-bottom textarea {
+  display: block;
+  resize: vertical;
+}
+
+form.go-bottom input.form-control, form.go-bottom textarea {
+  transition: padding 0.2s, color 0.2s, top 0.2s, bottom 0.2s, right 0.2s, left 0.2s;
+  padding: 12px 12px 12px 12px!important;
+}
+
+form.go-bottom input.form-control:focus, form.go-bottom textarea:focus {
+  transition: padding 0.2s, color 0.2s, top 0.2s, bottom 0.2s, right 0.2s, left 0.2s;
+  padding: 4px 12px 20px 12px!important;
+}
+
+form.go-bottom label {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+form.go-bottom input.form-control:focus + label, form.go-bottom textarea:focus + label {
+  top: 100%;
+  margin-top: -16px;
+}
+
+form.go-right label {
+  top: 2px;
+  right: 100%;
+  width: 100%;
+  margin-right: -100%;
+  bottom: 2px;
+}
+
+form.go-right input.form-control:focus + label, form.go-right textarea:focus + label {
+  right: 0;
+  margin-right: 0;
+  width: 40%;
+  padding-top: 5px;
+}
+
+form.go-bottom label #bigcheck{
+  margin-top: -50px;
+}
+
+input[type='checkbox'].bigcheck {
+  position: relative;
+  left: -999em; /* hide the real checkbox */
+}
+
+input[type='checkbox'].bigcheck + span.bigcheck-target:after {
+  content: "\f096"; /* In fontawesome, is an open square (fa-square-o) */
+  color: #71d5da;
+}
+
+input[type='checkbox'].bigcheck:checked + span.bigcheck-target:after {
+  content: "\f046"; /* fontawesome checked box (fa-check-square-o) */
+  position: initial;
+  color: #5cb85c;
+}
+
+input:focus {
+  background-color: white;
+  border: 1px solid #71d5da !important;
+}
+
+
+select {
+  font-size: 16px!important;
+  margin-right: 10px;
+  padding: 8px!important;
+}
+
 
 @-webkit-keyframes sk-stretchdelay {
-  0%, 40%, 100% { -webkit-transform: scaleY(0.4) }  
+  0%, 40%, 100% { -webkit-transform: scaleY(0.4) }
   20% { -webkit-transform: scaleY(1.0) }
 }
 
 @keyframes sk-stretchdelay {
-  0%, 40%, 100% { 
+  0%, 40%, 100% {
     transform: scaleY(0.4);
     -webkit-transform: scaleY(0.4);
-  }  20% { 
+  }  20% {
     transform: scaleY(1.0);
     -webkit-transform: scaleY(1.0);
+  }
+}
+
+
+@media screen {
+  .has-error input {
+    border-width: 2px;
+  }
+  .validation.text-danger:after {
+    content: 'Validation failed';
+  }
+  .validation.text-success:after {
+    content: 'Validation passed';
+  }
+  .col-xs-6, .col-xs-12 {
+    padding-left: 2px!important;
+    padding-right: 2px!important;
+  }
+  .header {
+    padding-top: 10px!important;
+    margin: 0 auto;
+  }
+}
+
+
+@media (max-device-width: 414px) {
+  ul li {
+    width: 72px;
+  }
+  ul li img{
+    width:40px;
+  }
+  .nav>li>a{
+        padding: 10px 0px;
+  }
+  .credit_card_tab>img{
+    width: 23px;
+  }
+}
+
+@media (max-device-width: 376px) {
+  ul li {
+    width: 64px;
+    margin: 2px;
+    border: none;
+  }
+  ul li img{
+    width:42px;
+  }
+  .nav>li>a{
+        padding: 10px 0px;
+  }
+  .credit_card_tab img{
+    width: 23px;
+  }
+}
+
+@media (max-device-width: 360px) {
+  ul li {
+    width: 54px;
+    margin: 2px;
+    border: none;
+  }
+  ul li img{
+    width:43px;
+  }
+  .nav>li>a{
+        padding: 6px 0px;
+  }
+  .credit_card_tab img{
+    width: 23px;
+  }
+}
+
+@media (max-device-width: 320px) {
+  ul li {
+    width: 54px;
+    margin: 2px;
+    border: none;
+  }
+  ul li img{
+    width:43px;
+  }
+  .nav>li>a{
+        padding: 6px 0px;
+  }
+  .credit_card_tab img{
+    width: 23px;
   }
 }

--- a/html/js/mondido.payment.js
+++ b/html/js/mondido.payment.js
@@ -328,6 +328,7 @@ jQuery(function($) {
 
       $('#row-customer-details').removeClass('hidden');
       $('#row-ssn-details-error').addClass('hidden');
+      $('#row-ssn-details-loading').addClass('hidden');
 
     } else {
 

--- a/html/js/mondido.payment.js
+++ b/html/js/mondido.payment.js
@@ -1,16 +1,18 @@
-  // v 1.14.2.1
+/*  Mondido mondido.payment.js v2.0, (c) Mondido Payments AB 2016, hello@mondido.com */
+
+/** * bootstrap.js v3.0.0 by @fat and @mdo * Copyright 2013 Twitter Inc.  * http://www.apache.org/licenses/LICENSE-2.0 */
+if(!jQuery)throw new Error("Bootstrap requires jQuery");+function(a){"use strict";function b(){var a=document.createElement("bootstrap"),b={WebkitTransition:"webkitTransitionEnd",MozTransition:"transitionend",OTransition:"oTransitionEnd otransitionend",transition:"transitionend"};for(var c in b)if(void 0!==a.style[c])return{end:b[c]}}a.fn.emulateTransitionEnd=function(b){var c=!1,d=this;a(this).one(a.support.transition.end,function(){c=!0});var e=function(){c||a(d).trigger(a.support.transition.end)};return setTimeout(e,b),this},a(function(){a.support.transition=b()})}(window.jQuery),+function(a){"use strict";var b='[data-dismiss="alert"]',c=function(c){a(c).on("click",b,this.close)};c.prototype.close=function(b){function c(){f.trigger("closed.bs.alert").remove()}var d=a(this),e=d.attr("data-target");e||(e=d.attr("href"),e=e&&e.replace(/.*(?=#[^\s]*$)/,""));var f=a(e);b&&b.preventDefault(),f.length||(f=d.hasClass("alert")?d:d.parent()),f.trigger(b=a.Event("close.bs.alert")),b.isDefaultPrevented()||(f.removeClass("in"),a.support.transition&&f.hasClass("fade")?f.one(a.support.transition.end,c).emulateTransitionEnd(150):c())};var d=a.fn.alert;a.fn.alert=function(b){return this.each(function(){var d=a(this),e=d.data("bs.alert");e||d.data("bs.alert",e=new c(this)),"string"==typeof b&&e[b].call(d)})},a.fn.alert.Constructor=c,a.fn.alert.noConflict=function(){return a.fn.alert=d,this},a(document).on("click.bs.alert.data-api",b,c.prototype.close)}(window.jQuery),+function(a){"use strict";var b=function(c,d){this.$element=a(c),this.options=a.extend({},b.DEFAULTS,d)};b.DEFAULTS={loadingText:"loading..."},b.prototype.setState=function(a){var b="disabled",c=this.$element,d=c.is("input")?"val":"html",e=c.data();a+="Text",e.resetText||c.data("resetText",c[d]()),c[d](e[a]||this.options[a]),setTimeout(function(){"loadingText"==a?c.addClass(b).attr(b,b):c.removeClass(b).removeAttr(b)},0)},b.prototype.toggle=function(){var a=this.$element.closest('[data-toggle="buttons"]');if(a.length){var b=this.$element.find("input").prop("checked",!this.$element.hasClass("active")).trigger("change");"radio"===b.prop("type")&&a.find(".active").removeClass("active")}this.$element.toggleClass("active")};var c=a.fn.button;a.fn.button=function(c){return this.each(function(){var d=a(this),e=d.data("bs.button"),f="object"==typeof c&&c;e||d.data("bs.button",e=new b(this,f)),"toggle"==c?e.toggle():c&&e.setState(c)})},a.fn.button.Constructor=b,a.fn.button.noConflict=function(){return a.fn.button=c,this},a(document).on("click.bs.button.data-api","[data-toggle^=button]",function(b){var c=a(b.target);c.hasClass("btn")||(c=c.closest(".btn")),c.button("toggle"),b.preventDefault()})}(window.jQuery),+function(a){"use strict";var b=function(b,c){this.$element=a(b),this.$indicators=this.$element.find(".carousel-indicators"),this.options=c,this.paused=this.sliding=this.interval=this.$active=this.$items=null,"hover"==this.options.pause&&this.$element.on("mouseenter",a.proxy(this.pause,this)).on("mouseleave",a.proxy(this.cycle,this))};b.DEFAULTS={interval:5e3,pause:"hover",wrap:!0},b.prototype.cycle=function(b){return b||(this.paused=!1),this.interval&&clearInterval(this.interval),this.options.interval&&!this.paused&&(this.interval=setInterval(a.proxy(this.next,this),this.options.interval)),this},b.prototype.getActiveIndex=function(){return this.$active=this.$element.find(".item.active"),this.$items=this.$active.parent().children(),this.$items.index(this.$active)},b.prototype.to=function(b){var c=this,d=this.getActiveIndex();return b>this.$items.length-1||0>b?void 0:this.sliding?this.$element.one("slid",function(){c.to(b)}):d==b?this.pause().cycle():this.slide(b>d?"next":"prev",a(this.$items[b]))},b.prototype.pause=function(b){return b||(this.paused=!0),this.$element.find(".next, .prev").length&&a.support.transition.end&&(this.$element.trigger(a.support.transition.end),this.cycle(!0)),this.interval=clearInterval(this.interval),this},b.prototype.next=function(){return this.sliding?void 0:this.slide("next")},b.prototype.prev=function(){return this.sliding?void 0:this.slide("prev")},b.prototype.slide=function(b,c){var d=this.$element.find(".item.active"),e=c||d[b](),f=this.interval,g="next"==b?"left":"right",h="next"==b?"first":"last",i=this;if(!e.length){if(!this.options.wrap)return;e=this.$element.find(".item")[h]()}this.sliding=!0,f&&this.pause();var j=a.Event("slide.bs.carousel",{relatedTarget:e[0],direction:g});if(!e.hasClass("active")){if(this.$indicators.length&&(this.$indicators.find(".active").removeClass("active"),this.$element.one("slid",function(){var b=a(i.$indicators.children()[i.getActiveIndex()]);b&&b.addClass("active")})),a.support.transition&&this.$element.hasClass("slide")){if(this.$element.trigger(j),j.isDefaultPrevented())return;e.addClass(b),e[0].offsetWidth,d.addClass(g),e.addClass(g),d.one(a.support.transition.end,function(){e.removeClass([b,g].join(" ")).addClass("active"),d.removeClass(["active",g].join(" ")),i.sliding=!1,setTimeout(function(){i.$element.trigger("slid")},0)}).emulateTransitionEnd(600)}else{if(this.$element.trigger(j),j.isDefaultPrevented())return;d.removeClass("active"),e.addClass("active"),this.sliding=!1,this.$element.trigger("slid")}return f&&this.cycle(),this}};var c=a.fn.carousel;a.fn.carousel=function(c){return this.each(function(){var d=a(this),e=d.data("bs.carousel"),f=a.extend({},b.DEFAULTS,d.data(),"object"==typeof c&&c),g="string"==typeof c?c:f.slide;e||d.data("bs.carousel",e=new b(this,f)),"number"==typeof c?e.to(c):g?e[g]():f.interval&&e.pause().cycle()})},a.fn.carousel.Constructor=b,a.fn.carousel.noConflict=function(){return a.fn.carousel=c,this},a(document).on("click.bs.carousel.data-api","[data-slide], [data-slide-to]",function(b){var c,d=a(this),e=a(d.attr("data-target")||(c=d.attr("href"))&&c.replace(/.*(?=#[^\s]+$)/,"")),f=a.extend({},e.data(),d.data()),g=d.attr("data-slide-to");g&&(f.interval=!1),e.carousel(f),(g=d.attr("data-slide-to"))&&e.data("bs.carousel").to(g),b.preventDefault()}),a(window).on("load",function(){a('[data-ride="carousel"]').each(function(){var b=a(this);b.carousel(b.data())})})}(window.jQuery),+function(a){"use strict";var b=function(c,d){this.$element=a(c),this.options=a.extend({},b.DEFAULTS,d),this.transitioning=null,this.options.parent&&(this.$parent=a(this.options.parent)),this.options.toggle&&this.toggle()};b.DEFAULTS={toggle:!0},b.prototype.dimension=function(){var a=this.$element.hasClass("width");return a?"width":"height"},b.prototype.show=function(){if(!this.transitioning&&!this.$element.hasClass("in")){var b=a.Event("show.bs.collapse");if(this.$element.trigger(b),!b.isDefaultPrevented()){var c=this.$parent&&this.$parent.find("> .panel > .in");if(c&&c.length){var d=c.data("bs.collapse");if(d&&d.transitioning)return;c.collapse("hide"),d||c.data("bs.collapse",null)}var e=this.dimension();this.$element.removeClass("collapse").addClass("collapsing")[e](0),this.transitioning=1;var f=function(){this.$element.removeClass("collapsing").addClass("in")[e]("auto"),this.transitioning=0,this.$element.trigger("shown.bs.collapse")};if(!a.support.transition)return f.call(this);var g=a.camelCase(["scroll",e].join("-"));this.$element.one(a.support.transition.end,a.proxy(f,this)).emulateTransitionEnd(350)[e](this.$element[0][g])}}},b.prototype.hide=function(){if(!this.transitioning&&this.$element.hasClass("in")){var b=a.Event("hide.bs.collapse");if(this.$element.trigger(b),!b.isDefaultPrevented()){var c=this.dimension();this.$element[c](this.$element[c]())[0].offsetHeight,this.$element.addClass("collapsing").removeClass("collapse").removeClass("in"),this.transitioning=1;var d=function(){this.transitioning=0,this.$element.trigger("hidden.bs.collapse").removeClass("collapsing").addClass("collapse")};return a.support.transition?(this.$element[c](0).one(a.support.transition.end,a.proxy(d,this)).emulateTransitionEnd(350),void 0):d.call(this)}}},b.prototype.toggle=function(){this[this.$element.hasClass("in")?"hide":"show"]()};var c=a.fn.collapse;a.fn.collapse=function(c){return this.each(function(){var d=a(this),e=d.data("bs.collapse"),f=a.extend({},b.DEFAULTS,d.data(),"object"==typeof c&&c);e||d.data("bs.collapse",e=new b(this,f)),"string"==typeof c&&e[c]()})},a.fn.collapse.Constructor=b,a.fn.collapse.noConflict=function(){return a.fn.collapse=c,this},a(document).on("click.bs.collapse.data-api","[data-toggle=collapse]",function(b){var c,d=a(this),e=d.attr("data-target")||b.preventDefault()||(c=d.attr("href"))&&c.replace(/.*(?=#[^\s]+$)/,""),f=a(e),g=f.data("bs.collapse"),h=g?"toggle":d.data(),i=d.attr("data-parent"),j=i&&a(i);g&&g.transitioning||(j&&j.find('[data-toggle=collapse][data-parent="'+i+'"]').not(d).addClass("collapsed"),d[f.hasClass("in")?"addClass":"removeClass"]("collapsed")),f.collapse(h)})}(window.jQuery),+function(a){"use strict";function b(){a(d).remove(),a(e).each(function(b){var d=c(a(this));d.hasClass("open")&&(d.trigger(b=a.Event("hide.bs.dropdown")),b.isDefaultPrevented()||d.removeClass("open").trigger("hidden.bs.dropdown"))})}function c(b){var c=b.attr("data-target");c||(c=b.attr("href"),c=c&&/#/.test(c)&&c.replace(/.*(?=#[^\s]*$)/,""));var d=c&&a(c);return d&&d.length?d:b.parent()}var d=".dropdown-backdrop",e="[data-toggle=dropdown]",f=function(b){a(b).on("click.bs.dropdown",this.toggle)};f.prototype.toggle=function(d){var e=a(this);if(!e.is(".disabled, :disabled")){var f=c(e),g=f.hasClass("open");if(b(),!g){if("ontouchstart"in document.documentElement&&!f.closest(".navbar-nav").length&&a('<div class="dropdown-backdrop"/>').insertAfter(a(this)).on("click",b),f.trigger(d=a.Event("show.bs.dropdown")),d.isDefaultPrevented())return;f.toggleClass("open").trigger("shown.bs.dropdown"),e.focus()}return!1}},f.prototype.keydown=function(b){if(/(38|40|27)/.test(b.keyCode)){var d=a(this);if(b.preventDefault(),b.stopPropagation(),!d.is(".disabled, :disabled")){var f=c(d),g=f.hasClass("open");if(!g||g&&27==b.keyCode)return 27==b.which&&f.find(e).focus(),d.click();var h=a("[role=menu] li:not(.divider):visible a",f);if(h.length){var i=h.index(h.filter(":focus"));38==b.keyCode&&i>0&&i--,40==b.keyCode&&i<h.length-1&&i++,~i||(i=0),h.eq(i).focus()}}}};var g=a.fn.dropdown;a.fn.dropdown=function(b){return this.each(function(){var c=a(this),d=c.data("dropdown");d||c.data("dropdown",d=new f(this)),"string"==typeof b&&d[b].call(c)})},a.fn.dropdown.Constructor=f,a.fn.dropdown.noConflict=function(){return a.fn.dropdown=g,this},a(document).on("click.bs.dropdown.data-api",b).on("click.bs.dropdown.data-api",".dropdown form",function(a){a.stopPropagation()}).on("click.bs.dropdown.data-api",e,f.prototype.toggle).on("keydown.bs.dropdown.data-api",e+", [role=menu]",f.prototype.keydown)}(window.jQuery),+function(a){"use strict";var b=function(b,c){this.options=c,this.$element=a(b),this.$backdrop=this.isShown=null,this.options.remote&&this.$element.load(this.options.remote)};b.DEFAULTS={backdrop:!0,keyboard:!0,show:!0},b.prototype.toggle=function(a){return this[this.isShown?"hide":"show"](a)},b.prototype.show=function(b){var c=this,d=a.Event("show.bs.modal",{relatedTarget:b});this.$element.trigger(d),this.isShown||d.isDefaultPrevented()||(this.isShown=!0,this.escape(),this.$element.on("click.dismiss.modal",'[data-dismiss="modal"]',a.proxy(this.hide,this)),this.backdrop(function(){var d=a.support.transition&&c.$element.hasClass("fade");c.$element.parent().length||c.$element.appendTo(document.body),c.$element.show(),d&&c.$element[0].offsetWidth,c.$element.addClass("in").attr("aria-hidden",!1),c.enforceFocus();var e=a.Event("shown.bs.modal",{relatedTarget:b});d?c.$element.find(".modal-dialog").one(a.support.transition.end,function(){c.$element.focus().trigger(e)}).emulateTransitionEnd(300):c.$element.focus().trigger(e)}))},b.prototype.hide=function(b){b&&b.preventDefault(),b=a.Event("hide.bs.modal"),this.$element.trigger(b),this.isShown&&!b.isDefaultPrevented()&&(this.isShown=!1,this.escape(),a(document).off("focusin.bs.modal"),this.$element.removeClass("in").attr("aria-hidden",!0).off("click.dismiss.modal"),a.support.transition&&this.$element.hasClass("fade")?this.$element.one(a.support.transition.end,a.proxy(this.hideModal,this)).emulateTransitionEnd(300):this.hideModal())},b.prototype.enforceFocus=function(){a(document).off("focusin.bs.modal").on("focusin.bs.modal",a.proxy(function(a){this.$element[0]===a.target||this.$element.has(a.target).length||this.$element.focus()},this))},b.prototype.escape=function(){this.isShown&&this.options.keyboard?this.$element.on("keyup.dismiss.bs.modal",a.proxy(function(a){27==a.which&&this.hide()},this)):this.isShown||this.$element.off("keyup.dismiss.bs.modal")},b.prototype.hideModal=function(){var a=this;this.$element.hide(),this.backdrop(function(){a.removeBackdrop(),a.$element.trigger("hidden.bs.modal")})},b.prototype.removeBackdrop=function(){this.$backdrop&&this.$backdrop.remove(),this.$backdrop=null},b.prototype.backdrop=function(b){var c=this.$element.hasClass("fade")?"fade":"";if(this.isShown&&this.options.backdrop){var d=a.support.transition&&c;if(this.$backdrop=a('<div class="modal-backdrop '+c+'" />').appendTo(document.body),this.$element.on("click.dismiss.modal",a.proxy(function(a){a.target===a.currentTarget&&("static"==this.options.backdrop?this.$element[0].focus.call(this.$element[0]):this.hide.call(this))},this)),d&&this.$backdrop[0].offsetWidth,this.$backdrop.addClass("in"),!b)return;d?this.$backdrop.one(a.support.transition.end,b).emulateTransitionEnd(150):b()}else!this.isShown&&this.$backdrop?(this.$backdrop.removeClass("in"),a.support.transition&&this.$element.hasClass("fade")?this.$backdrop.one(a.support.transition.end,b).emulateTransitionEnd(150):b()):b&&b()};var c=a.fn.modal;a.fn.modal=function(c,d){return this.each(function(){var e=a(this),f=e.data("bs.modal"),g=a.extend({},b.DEFAULTS,e.data(),"object"==typeof c&&c);f||e.data("bs.modal",f=new b(this,g)),"string"==typeof c?f[c](d):g.show&&f.show(d)})},a.fn.modal.Constructor=b,a.fn.modal.noConflict=function(){return a.fn.modal=c,this},a(document).on("click.bs.modal.data-api",'[data-toggle="modal"]',function(b){var c=a(this),d=c.attr("href"),e=a(c.attr("data-target")||d&&d.replace(/.*(?=#[^\s]+$)/,"")),f=e.data("modal")?"toggle":a.extend({remote:!/#/.test(d)&&d},e.data(),c.data());b.preventDefault(),e.modal(f,this).one("hide",function(){c.is(":visible")&&c.focus()})}),a(document).on("show.bs.modal",".modal",function(){a(document.body).addClass("modal-open")}).on("hidden.bs.modal",".modal",function(){a(document.body).removeClass("modal-open")})}(window.jQuery),+function(a){"use strict";var b=function(a,b){this.type=this.options=this.enabled=this.timeout=this.hoverState=this.$element=null,this.init("tooltip",a,b)};b.DEFAULTS={animation:!0,placement:"top",selector:!1,template:'<div class="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',trigger:"hover focus",title:"",delay:0,html:!1,container:!1},b.prototype.init=function(b,c,d){this.enabled=!0,this.type=b,this.$element=a(c),this.options=this.getOptions(d);for(var e=this.options.trigger.split(" "),f=e.length;f--;){var g=e[f];if("click"==g)this.$element.on("click."+this.type,this.options.selector,a.proxy(this.toggle,this));else if("manual"!=g){var h="hover"==g?"mouseenter":"focus",i="hover"==g?"mouseleave":"blur";this.$element.on(h+"."+this.type,this.options.selector,a.proxy(this.enter,this)),this.$element.on(i+"."+this.type,this.options.selector,a.proxy(this.leave,this))}}this.options.selector?this._options=a.extend({},this.options,{trigger:"manual",selector:""}):this.fixTitle()},b.prototype.getDefaults=function(){return b.DEFAULTS},b.prototype.getOptions=function(b){return b=a.extend({},this.getDefaults(),this.$element.data(),b),b.delay&&"number"==typeof b.delay&&(b.delay={show:b.delay,hide:b.delay}),b},b.prototype.getDelegateOptions=function(){var b={},c=this.getDefaults();return this._options&&a.each(this._options,function(a,d){c[a]!=d&&(b[a]=d)}),b},b.prototype.enter=function(b){var c=b instanceof this.constructor?b:a(b.currentTarget)[this.type](this.getDelegateOptions()).data("bs."+this.type);return clearTimeout(c.timeout),c.hoverState="in",c.options.delay&&c.options.delay.show?(c.timeout=setTimeout(function(){"in"==c.hoverState&&c.show()},c.options.delay.show),void 0):c.show()},b.prototype.leave=function(b){var c=b instanceof this.constructor?b:a(b.currentTarget)[this.type](this.getDelegateOptions()).data("bs."+this.type);return clearTimeout(c.timeout),c.hoverState="out",c.options.delay&&c.options.delay.hide?(c.timeout=setTimeout(function(){"out"==c.hoverState&&c.hide()},c.options.delay.hide),void 0):c.hide()},b.prototype.show=function(){var b=a.Event("show.bs."+this.type);if(this.hasContent()&&this.enabled){if(this.$element.trigger(b),b.isDefaultPrevented())return;var c=this.tip();this.setContent(),this.options.animation&&c.addClass("fade");var d="function"==typeof this.options.placement?this.options.placement.call(this,c[0],this.$element[0]):this.options.placement,e=/\s?auto?\s?/i,f=e.test(d);f&&(d=d.replace(e,"")||"top"),c.detach().css({top:0,left:0,display:"block"}).addClass(d),this.options.container?c.appendTo(this.options.container):c.insertAfter(this.$element);var g=this.getPosition(),h=c[0].offsetWidth,i=c[0].offsetHeight;if(f){var j=this.$element.parent(),k=d,l=document.documentElement.scrollTop||document.body.scrollTop,m="body"==this.options.container?window.innerWidth:j.outerWidth(),n="body"==this.options.container?window.innerHeight:j.outerHeight(),o="body"==this.options.container?0:j.offset().left;d="bottom"==d&&g.top+g.height+i-l>n?"top":"top"==d&&g.top-l-i<0?"bottom":"right"==d&&g.right+h>m?"left":"left"==d&&g.left-h<o?"right":d,c.removeClass(k).addClass(d)}var p=this.getCalculatedOffset(d,g,h,i);this.applyPlacement(p,d),this.$element.trigger("shown.bs."+this.type)}},b.prototype.applyPlacement=function(a,b){var c,d=this.tip(),e=d[0].offsetWidth,f=d[0].offsetHeight,g=parseInt(d.css("margin-top"),10),h=parseInt(d.css("margin-left"),10);isNaN(g)&&(g=0),isNaN(h)&&(h=0),a.top=a.top+g,a.left=a.left+h,d.offset(a).addClass("in");var i=d[0].offsetWidth,j=d[0].offsetHeight;if("top"==b&&j!=f&&(c=!0,a.top=a.top+f-j),/bottom|top/.test(b)){var k=0;a.left<0&&(k=-2*a.left,a.left=0,d.offset(a),i=d[0].offsetWidth,j=d[0].offsetHeight),this.replaceArrow(k-e+i,i,"left")}else this.replaceArrow(j-f,j,"top");c&&d.offset(a)},b.prototype.replaceArrow=function(a,b,c){this.arrow().css(c,a?50*(1-a/b)+"%":"")},b.prototype.setContent=function(){var a=this.tip(),b=this.getTitle();a.find(".tooltip-inner")[this.options.html?"html":"text"](b),a.removeClass("fade in top bottom left right")},b.prototype.hide=function(){function b(){"in"!=c.hoverState&&d.detach()}var c=this,d=this.tip(),e=a.Event("hide.bs."+this.type);return this.$element.trigger(e),e.isDefaultPrevented()?void 0:(d.removeClass("in"),a.support.transition&&this.$tip.hasClass("fade")?d.one(a.support.transition.end,b).emulateTransitionEnd(150):b(),this.$element.trigger("hidden.bs."+this.type),this)},b.prototype.fixTitle=function(){var a=this.$element;(a.attr("title")||"string"!=typeof a.attr("data-original-title"))&&a.attr("data-original-title",a.attr("title")||"").attr("title","")},b.prototype.hasContent=function(){return this.getTitle()},b.prototype.getPosition=function(){var b=this.$element[0];return a.extend({},"function"==typeof b.getBoundingClientRect?b.getBoundingClientRect():{width:b.offsetWidth,height:b.offsetHeight},this.$element.offset())},b.prototype.getCalculatedOffset=function(a,b,c,d){return"bottom"==a?{top:b.top+b.height,left:b.left+b.width/2-c/2}:"top"==a?{top:b.top-d,left:b.left+b.width/2-c/2}:"left"==a?{top:b.top+b.height/2-d/2,left:b.left-c}:{top:b.top+b.height/2-d/2,left:b.left+b.width}},b.prototype.getTitle=function(){var a,b=this.$element,c=this.options;return a=b.attr("data-original-title")||("function"==typeof c.title?c.title.call(b[0]):c.title)},b.prototype.tip=function(){return this.$tip=this.$tip||a(this.options.template)},b.prototype.arrow=function(){return this.$arrow=this.$arrow||this.tip().find(".tooltip-arrow")},b.prototype.validate=function(){this.$element[0].parentNode||(this.hide(),this.$element=null,this.options=null)},b.prototype.enable=function(){this.enabled=!0},b.prototype.disable=function(){this.enabled=!1},b.prototype.toggleEnabled=function(){this.enabled=!this.enabled},b.prototype.toggle=function(b){var c=b?a(b.currentTarget)[this.type](this.getDelegateOptions()).data("bs."+this.type):this;c.tip().hasClass("in")?c.leave(c):c.enter(c)},b.prototype.destroy=function(){this.hide().$element.off("."+this.type).removeData("bs."+this.type)};var c=a.fn.tooltip;a.fn.tooltip=function(c){return this.each(function(){var d=a(this),e=d.data("bs.tooltip"),f="object"==typeof c&&c;e||d.data("bs.tooltip",e=new b(this,f)),"string"==typeof c&&e[c]()})},a.fn.tooltip.Constructor=b,a.fn.tooltip.noConflict=function(){return a.fn.tooltip=c,this}}(window.jQuery),+function(a){"use strict";var b=function(a,b){this.init("popover",a,b)};if(!a.fn.tooltip)throw new Error("Popover requires tooltip.js");b.DEFAULTS=a.extend({},a.fn.tooltip.Constructor.DEFAULTS,{placement:"right",trigger:"click",content:"",template:'<div class="popover"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>'}),b.prototype=a.extend({},a.fn.tooltip.Constructor.prototype),b.prototype.constructor=b,b.prototype.getDefaults=function(){return b.DEFAULTS},b.prototype.setContent=function(){var a=this.tip(),b=this.getTitle(),c=this.getContent();a.find(".popover-title")[this.options.html?"html":"text"](b),a.find(".popover-content")[this.options.html?"html":"text"](c),a.removeClass("fade top bottom left right in"),a.find(".popover-title").html()||a.find(".popover-title").hide()},b.prototype.hasContent=function(){return this.getTitle()||this.getContent()},b.prototype.getContent=function(){var a=this.$element,b=this.options;return a.attr("data-content")||("function"==typeof b.content?b.content.call(a[0]):b.content)},b.prototype.arrow=function(){return this.$arrow=this.$arrow||this.tip().find(".arrow")},b.prototype.tip=function(){return this.$tip||(this.$tip=a(this.options.template)),this.$tip};var c=a.fn.popover;a.fn.popover=function(c){return this.each(function(){var d=a(this),e=d.data("bs.popover"),f="object"==typeof c&&c;e||d.data("bs.popover",e=new b(this,f)),"string"==typeof c&&e[c]()})},a.fn.popover.Constructor=b,a.fn.popover.noConflict=function(){return a.fn.popover=c,this}}(window.jQuery),+function(a){"use strict";function b(c,d){var e,f=a.proxy(this.process,this);this.$element=a(c).is("body")?a(window):a(c),this.$body=a("body"),this.$scrollElement=this.$element.on("scroll.bs.scroll-spy.data-api",f),this.options=a.extend({},b.DEFAULTS,d),this.selector=(this.options.target||(e=a(c).attr("href"))&&e.replace(/.*(?=#[^\s]+$)/,"")||"")+" .nav li > a",this.offsets=a([]),this.targets=a([]),this.activeTarget=null,this.refresh(),this.process()}b.DEFAULTS={offset:10},b.prototype.refresh=function(){var b=this.$element[0]==window?"offset":"position";this.offsets=a([]),this.targets=a([]);var c=this;this.$body.find(this.selector).map(function(){var d=a(this),e=d.data("target")||d.attr("href"),f=/^#\w/.test(e)&&a(e);return f&&f.length&&[[f[b]().top+(!a.isWindow(c.$scrollElement.get(0))&&c.$scrollElement.scrollTop()),e]]||null}).sort(function(a,b){return a[0]-b[0]}).each(function(){c.offsets.push(this[0]),c.targets.push(this[1])})},b.prototype.process=function(){var a,b=this.$scrollElement.scrollTop()+this.options.offset,c=this.$scrollElement[0].scrollHeight||this.$body[0].scrollHeight,d=c-this.$scrollElement.height(),e=this.offsets,f=this.targets,g=this.activeTarget;if(b>=d)return g!=(a=f.last()[0])&&this.activate(a);for(a=e.length;a--;)g!=f[a]&&b>=e[a]&&(!e[a+1]||b<=e[a+1])&&this.activate(f[a])},b.prototype.activate=function(b){this.activeTarget=b,a(this.selector).parents(".active").removeClass("active");var c=this.selector+'[data-target="'+b+'"],'+this.selector+'[href="'+b+'"]',d=a(c).parents("li").addClass("active");d.parent(".dropdown-menu").length&&(d=d.closest("li.dropdown").addClass("active")),d.trigger("activate")};var c=a.fn.scrollspy;a.fn.scrollspy=function(c){return this.each(function(){var d=a(this),e=d.data("bs.scrollspy"),f="object"==typeof c&&c;e||d.data("bs.scrollspy",e=new b(this,f)),"string"==typeof c&&e[c]()})},a.fn.scrollspy.Constructor=b,a.fn.scrollspy.noConflict=function(){return a.fn.scrollspy=c,this},a(window).on("load",function(){a('[data-spy="scroll"]').each(function(){var b=a(this);b.scrollspy(b.data())})})}(window.jQuery),+function(a){"use strict";var b=function(b){this.element=a(b)};b.prototype.show=function(){var b=this.element,c=b.closest("ul:not(.dropdown-menu)"),d=b.attr("data-target");if(d||(d=b.attr("href"),d=d&&d.replace(/.*(?=#[^\s]*$)/,"")),!b.parent("li").hasClass("active")){var e=c.find(".active:last a")[0],f=a.Event("show.bs.tab",{relatedTarget:e});if(b.trigger(f),!f.isDefaultPrevented()){var g=a(d);this.activate(b.parent("li"),c),this.activate(g,g.parent(),function(){b.trigger({type:"shown.bs.tab",relatedTarget:e})})}}},b.prototype.activate=function(b,c,d){function e(){f.removeClass("active").find("> .dropdown-menu > .active").removeClass("active"),b.addClass("active"),g?(b[0].offsetWidth,b.addClass("in")):b.removeClass("fade"),b.parent(".dropdown-menu")&&b.closest("li.dropdown").addClass("active"),d&&d()}var f=c.find("> .active"),g=d&&a.support.transition&&f.hasClass("fade");g?f.one(a.support.transition.end,e).emulateTransitionEnd(150):e(),f.removeClass("in")};var c=a.fn.tab;a.fn.tab=function(c){return this.each(function(){var d=a(this),e=d.data("bs.tab");e||d.data("bs.tab",e=new b(this)),"string"==typeof c&&e[c]()})},a.fn.tab.Constructor=b,a.fn.tab.noConflict=function(){return a.fn.tab=c,this},a(document).on("click.bs.tab.data-api",'[data-toggle="tab"], [data-toggle="pill"]',function(b){b.preventDefault(),a(this).tab("show")})}(window.jQuery),+function(a){"use strict";var b=function(c,d){this.options=a.extend({},b.DEFAULTS,d),this.$window=a(window).on("scroll.bs.affix.data-api",a.proxy(this.checkPosition,this)).on("click.bs.affix.data-api",a.proxy(this.checkPositionWithEventLoop,this)),this.$element=a(c),this.affixed=this.unpin=null,this.checkPosition()};b.RESET="affix affix-top affix-bottom",b.DEFAULTS={offset:0},b.prototype.checkPositionWithEventLoop=function(){setTimeout(a.proxy(this.checkPosition,this),1)},b.prototype.checkPosition=function(){if(this.$element.is(":visible")){var c=a(document).height(),d=this.$window.scrollTop(),e=this.$element.offset(),f=this.options.offset,g=f.top,h=f.bottom;"object"!=typeof f&&(h=g=f),"function"==typeof g&&(g=f.top()),"function"==typeof h&&(h=f.bottom());var i=null!=this.unpin&&d+this.unpin<=e.top?!1:null!=h&&e.top+this.$element.height()>=c-h?"bottom":null!=g&&g>=d?"top":!1;this.affixed!==i&&(this.unpin&&this.$element.css("top",""),this.affixed=i,this.unpin="bottom"==i?e.top-d:null,this.$element.removeClass(b.RESET).addClass("affix"+(i?"-"+i:"")),"bottom"==i&&this.$element.offset({top:document.body.offsetHeight-h-this.$element.height()}))}};var c=a.fn.affix;a.fn.affix=function(c){return this.each(function(){var d=a(this),e=d.data("bs.affix"),f="object"==typeof c&&c;e||d.data("bs.affix",e=new b(this,f)),"string"==typeof c&&e[c]()})},a.fn.affix.Constructor=b,a.fn.affix.noConflict=function(){return a.fn.affix=c,this},a(window).on("load",function(){a('[data-spy="affix"]').each(function(){var b=a(this),c=b.data();c.offset=c.offset||{},c.offsetBottom&&(c.offset.bottom=c.offsetBottom),c.offsetTop&&(c.offset.top=c.offsetTop),b.affix(c)})})}(window.jQuery);
 
 // Mondido settings
 (function($) {
-  var do_log = function(str){
-    if(window.console){
+
+  var do_log = function(str) {
+    if (window.console) {
       console.log(str);
     }
   };
 
-  if (mondidoSettings.config.development == true){
-    do_log("Development mode is on");
-  }
+  if (mondidoSettings.config.development == true) { do_log("Development mode is on");  }
 
   if (typeof Mondido === "undefined") {
     console.log("Error could not load Mondido object");
@@ -24,9 +26,60 @@
       }
     };
   }
+  $_mondido_ssn_load_value = "";
 
-  invoice = $.grep(mondidoSettings.supportedPaymentMethods, function(e){ return e.name == "invoice_tab"; });
-  $("#accept_collector").attr("data-mulang", "invoice_accept_conditions['"+mondidoSettings.layout.name+"','"+mondidoSettings.layout.terms_and_conditions_url+"','"+invoice[0].AgreementCode+"','"+invoice[0].AgreementCode+"']");
+  // Preload
+  if (!isBlank(mondidoSettings.customer.name) && isBlank($('#input_card_holder').val())) {
+    $('#input_card_holder').val(mondidoSettings.customer.name);
+  }
+  if (!isBlank(mondidoSettings.customer.phone) && isBlank($('#phone').val())) {
+    $('#phone').val(mondidoSettings.customer.phone);
+  }
+  if (!isBlank(mondidoSettings.customer.phone) && isBlank($('#swish_number').val())) {
+    $('#swish_number').val(mondidoSettings.customer.phone);
+  }
+  if (!isBlank(mondidoSettings.customer.email) && isBlank($('#email').val())) {
+    $('#email').val(mondidoSettings.customer.email);
+  }
+  if (!isBlank(mondidoSettings.customer.billing.first_name) && isBlank($('#first_name').val())) {
+    $('#first_name').val(mondidoSettings.customer.billing.first_name);
+  }
+  if (!isBlank(mondidoSettings.customer.billing.last_name) && isBlank($('#last_name').val())) {
+    $('#last_name').val(mondidoSettings.customer.billing.last_name);
+  }
+  if (!isBlank(mondidoSettings.customer.billing.zip) && isBlank($('#zip').val())) {
+    $('#zip').val(mondidoSettings.customer.billing.zip);
+  }
+  if (!isBlank(mondidoSettings.customer.billing.city) && isBlank($('#city').val())) {
+    $('#city').val(mondidoSettings.customer.billing.city);
+  }
+  if (!isBlank(mondidoSettings.customer.billing.address1) && isBlank($('#address_1').val())) {
+    $('#address_1').val(mondidoSettings.customer.billing.address1);
+  }
+  if (!isBlank(mondidoSettings.customer.billing.city) && isBlank($('#address_2').val())) {
+    $('#address_2').val(mondidoSettings.customer.billing.address2);
+  }
+
+  setCountryCode(mondidoSettings.country_code);
+
+  function setCountryCode(str) {
+    mondidoSettings.country_code = str;
+    $('#country_code').val(str);
+  }
+
+  switch (mondidoSettings.metadataCountry) {
+    case 'Sweden':
+      setCountryCode('swe');
+      break;
+    case 'Norway':
+      setCountryCode('nor');
+      break;
+    case 'Finland':
+      setCountryCode('fin');
+      break;
+    default:
+      setCountryCode('swe');
+  }
 
 })(jQuery);
 
@@ -38,2020 +91,1172 @@
 */
 !function(a){"function"==typeof define&&define.amd?define(["jquery"],a):a("object"==typeof exports?require("jquery"):jQuery)}(function(a){var b,c=navigator.userAgent,d=/iphone/i.test(c),e=/chrome/i.test(c),f=/android/i.test(c);a.mask={definitions:{9:"[0-9]",a:"[A-Za-z]","*":"[A-Za-z0-9]"},autoclear:!0,dataName:"rawMaskFn",placeholder:"_"},a.fn.extend({caret:function(a,b){var c;if(0!==this.length&&!this.is(":hidden"))return"number"==typeof a?(b="number"==typeof b?b:a,this.each(function(){this.setSelectionRange?this.setSelectionRange(a,b):this.createTextRange&&(c=this.createTextRange(),c.collapse(!0),c.moveEnd("character",b),c.moveStart("character",a),c.select())})):(this[0].setSelectionRange?(a=this[0].selectionStart,b=this[0].selectionEnd):document.selection&&document.selection.createRange&&(c=document.selection.createRange(),a=0-c.duplicate().moveStart("character",-1e5),b=a+c.text.length),{begin:a,end:b})},unmask:function(){return this.trigger("unmask")},mask:function(c,g){var h,i,j,k,l,m,n,o;if(!c&&this.length>0){h=a(this[0]);var p=h.data(a.mask.dataName);return p?p():void 0}return g=a.extend({autoclear:a.mask.autoclear,placeholder:a.mask.placeholder,completed:null},g),i=a.mask.definitions,j=[],k=n=c.length,l=null,a.each(c.split(""),function(a,b){"?"==b?(n--,k=a):i[b]?(j.push(new RegExp(i[b])),null===l&&(l=j.length-1),k>a&&(m=j.length-1)):j.push(null)}),this.trigger("unmask").each(function(){function h(){if(g.completed){for(var a=l;m>=a;a++)if(j[a]&&C[a]===p(a))return;g.completed.call(B)}}function p(a){return g.placeholder.charAt(a<g.placeholder.length?a:0)}function q(a){for(;++a<n&&!j[a];);return a}function r(a){for(;--a>=0&&!j[a];);return a}function s(a,b){var c,d;if(!(0>a)){for(c=a,d=q(b);n>c;c++)if(j[c]){if(!(n>d&&j[c].test(C[d])))break;C[c]=C[d],C[d]=p(d),d=q(d)}z(),B.caret(Math.max(l,a))}}function t(a){var b,c,d,e;for(b=a,c=p(a);n>b;b++)if(j[b]){if(d=q(b),e=C[b],C[b]=c,!(n>d&&j[d].test(e)))break;c=e}}function u(){var a=B.val(),b=B.caret();if(a.length<o.length){for(A(!0);b.begin>0&&!j[b.begin-1];)b.begin--;if(0===b.begin)for(;b.begin<l&&!j[b.begin];)b.begin++;B.caret(b.begin,b.begin)}else{for(A(!0);b.begin<n&&!j[b.begin];)b.begin++;B.caret(b.begin,b.begin)}h()}function v(){A(),B.val()!=E&&B.change()}function w(a){if(!B.prop("readonly")){var b,c,e,f=a.which||a.keyCode;o=B.val(),8===f||46===f||d&&127===f?(b=B.caret(),c=b.begin,e=b.end,e-c===0&&(c=46!==f?r(c):e=q(c-1),e=46===f?q(e):e),y(c,e),s(c,e-1),a.preventDefault()):13===f?v.call(this,a):27===f&&(B.val(E),B.caret(0,A()),a.preventDefault())}}function x(b){if(!B.prop("readonly")){var c,d,e,g=b.which||b.keyCode,i=B.caret();if(!(b.ctrlKey||b.altKey||b.metaKey||32>g)&&g&&13!==g){if(i.end-i.begin!==0&&(y(i.begin,i.end),s(i.begin,i.end-1)),c=q(i.begin-1),n>c&&(d=String.fromCharCode(g),j[c].test(d))){if(t(c),C[c]=d,z(),e=q(c),f){var k=function(){a.proxy(a.fn.caret,B,e)()};setTimeout(k,0)}else B.caret(e);i.begin<=m&&h()}b.preventDefault()}}}function y(a,b){var c;for(c=a;b>c&&n>c;c++)j[c]&&(C[c]=p(c))}function z(){B.val(C.join(""))}function A(a){var b,c,d,e=B.val(),f=-1;for(b=0,d=0;n>b;b++)if(j[b]){for(C[b]=p(b);d++<e.length;)if(c=e.charAt(d-1),j[b].test(c)){C[b]=c,f=b;break}if(d>e.length){y(b+1,n);break}}else C[b]===e.charAt(d)&&d++,k>b&&(f=b);return a?z():k>f+1?g.autoclear||C.join("")===D?(B.val()&&B.val(""),y(0,n)):z():(z(),B.val(B.val().substring(0,f+1))),k?b:l}var B=a(this),C=a.map(c.split(""),function(a,b){return"?"!=a?i[a]?p(b):a:void 0}),D=C.join(""),E=B.val();B.data(a.mask.dataName,function(){return a.map(C,function(a,b){return j[b]&&a!=p(b)?a:null}).join("")}),B.one("unmask",function(){B.off(".mask").removeData(a.mask.dataName)}).on("focus.mask",function(){if(!B.prop("readonly")){clearTimeout(b);var a;E=B.val(),a=A(),b=setTimeout(function(){z(),a==c.replace("?","").length?B.caret(0,a):B.caret(a)},10)}}).on("blur.mask",v).on("keydown.mask",w).on("keypress.mask",x).on("input.mask paste.mask",function(){B.prop("readonly")||setTimeout(function(){var a=A(!0);B.caret(a),h()},0)}),e&&f&&B.off("input.mask").on("input.mask",u),A()})}})});
 
+// https://github.com/stripe/jquery.payment - 2.0.0
+(function(){var t,e,n,r,a,o,i,l,u,s,c,h,p,g,v,f,d,m,y,C,T,w,$,D,S=[].slice,k=[].indexOf||function(t){for(var e=0,n=this.length;n>e;e++)if(e in this&&this[e]===t)return e;return-1};t=window.jQuery||window.Zepto||window.$,t.payment={},t.payment.fn={},t.fn.payment=function(){var e,n;return n=arguments[0],e=2<=arguments.length?S.call(arguments,1):[],t.payment.fn[n].apply(this,e)},a=/(\d{1,4})/g,t.payment.cards=r=[{type:"elo",patterns:[401178,401179,431274,438935,451416,457393,457631,457632,504175,506699,5067,509,627780,636297,636368,650,6516,6550],format:a,length:[16],cvcLength:[3],luhn:!0},{type:"maestro",patterns:[5018,502,503,506,56,58,639,6220,67],format:a,length:[12,13,14,15,16,17,18,19],cvcLength:[3],luhn:!0},{type:"forbrugsforeningen",patterns:[600],format:a,length:[16],cvcLength:[3],luhn:!0},{type:"dankort",patterns:[5019],format:a,length:[16],cvcLength:[3],luhn:!0},{type:"visa",patterns:[4],format:a,length:[13,16],cvcLength:[3],luhn:!0},{type:"mastercard",patterns:[51,52,53,54,55,22,23,24,25,26,27],format:a,length:[16],cvcLength:[3],luhn:!0},{type:"amex",patterns:[34,37],format:/(\d{1,4})(\d{1,6})?(\d{1,5})?/,length:[15],cvcLength:[3,4],luhn:!0},{type:"dinersclub",patterns:[30,36,38,39],format:/(\d{1,4})(\d{1,6})?(\d{1,4})?/,length:[14],cvcLength:[3],luhn:!0},{type:"discover",patterns:[60,64,65,622],format:a,length:[16],cvcLength:[3],luhn:!0},{type:"unionpay",patterns:[62,88],format:a,length:[16,17,18,19],cvcLength:[3],luhn:!1},{type:"jcb",patterns:[35],format:a,length:[16],cvcLength:[3],luhn:!0}],e=function(t){var e,n,a,o,i,l,u,s;for(t=(t+"").replace(/\D/g,""),o=0,l=r.length;l>o;o++)for(e=r[o],s=e.patterns,i=0,u=s.length;u>i;i++)if(a=s[i],n=a+"",t.substr(0,n.length)===n)return e},n=function(t){var e,n,a;for(n=0,a=r.length;a>n;n++)if(e=r[n],e.type===t)return e},p=function(t){var e,n,r,a,o,i;for(r=!0,a=0,n=(t+"").split("").reverse(),o=0,i=n.length;i>o;o++)e=n[o],e=parseInt(e,10),(r=!r)&&(e*=2),e>9&&(e-=9),a+=e;return a%10===0},h=function(t){var e;return null!=t.prop("selectionStart")&&t.prop("selectionStart")!==t.prop("selectionEnd")?!0:null!=("undefined"!=typeof document&&null!==document&&null!=(e=document.selection)?e.createRange:void 0)&&document.selection.createRange().text?!0:!1},$=function(t,e){var n,r,a,o,i,l;try{r=e.prop("selectionStart")}catch(u){o=u,r=null}return i=e.val(),e.val(t),null!==r&&e.is(":focus")?(r===i.length&&(r=t.length),i!==t&&(l=i.slice(r-1,+r+1||9e9),n=t.slice(r-1,+r+1||9e9),a=t[r],/\d/.test(a)&&l===""+a+" "&&n===" "+a&&(r+=1)),e.prop("selectionStart",r),e.prop("selectionEnd",r)):void 0},m=function(t){var e,n,r,a,o,i,l,u;for(null==t&&(t=""),r="０１２３４５６７８９",a="0123456789",i="",e=t.split(""),l=0,u=e.length;u>l;l++)n=e[l],o=r.indexOf(n),o>-1&&(n=a[o]),i+=n;return i},d=function(e){var n;return n=t(e.currentTarget),setTimeout(function(){var t;return t=n.val(),t=m(t),t=t.replace(/\D/g,""),$(t,n)})},v=function(e){var n;return n=t(e.currentTarget),setTimeout(function(){var e;return e=n.val(),e=m(e),e=t.payment.formatCardNumber(e),$(e,n)})},l=function(n){var r,a,o,i,l,u,s;return o=String.fromCharCode(n.which),!/^\d+$/.test(o)||(r=t(n.currentTarget),s=r.val(),a=e(s+o),i=(s.replace(/\D/g,"")+o).length,u=16,a&&(u=a.length[a.length.length-1]),i>=u||null!=r.prop("selectionStart")&&r.prop("selectionStart")!==s.length)?void 0:(l=a&&"amex"===a.type?/^(\d{4}|\d{4}\s\d{6})$/:/(?:^|\s)(\d{4})$/,l.test(s)?(n.preventDefault(),setTimeout(function(){return r.val(s+" "+o)})):l.test(s+o)?(n.preventDefault(),setTimeout(function(){return r.val(s+o+" ")})):void 0)},o=function(e){var n,r;return n=t(e.currentTarget),r=n.val(),8!==e.which||null!=n.prop("selectionStart")&&n.prop("selectionStart")!==r.length?void 0:/\d\s$/.test(r)?(e.preventDefault(),setTimeout(function(){return n.val(r.replace(/\d\s$/,""))})):/\s\d?$/.test(r)?(e.preventDefault(),setTimeout(function(){return n.val(r.replace(/\d$/,""))})):void 0},f=function(e){var n;return n=t(e.currentTarget),setTimeout(function(){var e;return e=n.val(),e=m(e),e=t.payment.formatExpiry(e),$(e,n)})},u=function(e){var n,r,a;return r=String.fromCharCode(e.which),/^\d+$/.test(r)?(n=t(e.currentTarget),a=n.val()+r,/^\d$/.test(a)&&"0"!==a&&"1"!==a?(e.preventDefault(),setTimeout(function(){return n.val("0"+a+" / ")})):/^\d\d$/.test(a)?(e.preventDefault(),setTimeout(function(){var t,e;return t=parseInt(a[0],10),e=parseInt(a[1],10),e>2&&0!==t?n.val("0"+t+" / "+e):n.val(""+a+" / ")})):void 0):void 0},s=function(e){var n,r,a;return r=String.fromCharCode(e.which),/^\d+$/.test(r)?(n=t(e.currentTarget),a=n.val(),/^\d\d$/.test(a)?n.val(""+a+" / "):void 0):void 0},c=function(e){var n,r,a;return a=String.fromCharCode(e.which),"/"===a||" "===a?(n=t(e.currentTarget),r=n.val(),/^\d$/.test(r)&&"0"!==r?n.val("0"+r+" / "):void 0):void 0},i=function(e){var n,r;return n=t(e.currentTarget),r=n.val(),8!==e.which||null!=n.prop("selectionStart")&&n.prop("selectionStart")!==r.length?void 0:/\d\s\/\s$/.test(r)?(e.preventDefault(),setTimeout(function(){return n.val(r.replace(/\d\s\/\s$/,""))})):void 0},g=function(e){var n;return n=t(e.currentTarget),setTimeout(function(){var t;return t=n.val(),t=m(t),t=t.replace(/\D/g,"").slice(0,4),$(t,n)})},w=function(t){var e;return t.metaKey||t.ctrlKey?!0:32===t.which?!1:0===t.which?!0:t.which<33?!0:(e=String.fromCharCode(t.which),!!/[\d\s]/.test(e))},C=function(n){var r,a,o,i;return r=t(n.currentTarget),o=String.fromCharCode(n.which),/^\d+$/.test(o)&&!h(r)?(i=(r.val()+o).replace(/\D/g,""),a=e(i),a?i.length<=a.length[a.length.length-1]:i.length<=16):void 0},T=function(e){var n,r,a;return n=t(e.currentTarget),r=String.fromCharCode(e.which),/^\d+$/.test(r)&&!h(n)?(a=n.val()+r,a=a.replace(/\D/g,""),a.length>6?!1:void 0):void 0},y=function(e){var n,r,a;return n=t(e.currentTarget),r=String.fromCharCode(e.which),/^\d+$/.test(r)&&!h(n)?(a=n.val()+r,a.length<=4):void 0},D=function(e){var n,a,o,i,l;return n=t(e.currentTarget),l=n.val(),i=t.payment.cardType(l)||"unknown",n.hasClass(i)?void 0:(a=function(){var t,e,n;for(n=[],t=0,e=r.length;e>t;t++)o=r[t],n.push(o.type);return n}(),n.removeClass("unknown"),n.removeClass(a.join(" ")),n.addClass(i),n.toggleClass("identified","unknown"!==i),n.trigger("payment.cardType",i))},t.payment.fn.formatCardCVC=function(){return this.on("keypress",w),this.on("keypress",y),this.on("paste",g),this.on("change",g),this.on("input",g),this},t.payment.fn.formatCardExpiry=function(){return this.on("keypress",w),this.on("keypress",T),this.on("keypress",u),this.on("keypress",c),this.on("keypress",s),this.on("keydown",i),this.on("change",f),this.on("input",f),this},t.payment.fn.formatCardNumber=function(){return this.on("keypress",w),this.on("keypress",C),this.on("keypress",l),this.on("keydown",o),this.on("keyup",D),this.on("paste",v),this.on("change",v),this.on("input",v),this.on("input",D),this},t.payment.fn.restrictNumeric=function(){return this.on("keypress",w),this.on("paste",d),this.on("change",d),this.on("input",d),this},t.payment.fn.cardExpiryVal=function(){return t.payment.cardExpiryVal(t(this).val())},t.payment.cardExpiryVal=function(t){var e,n,r,a;return a=t.split(/[\s\/]+/,2),e=a[0],r=a[1],2===(null!=r?r.length:void 0)&&/^\d+$/.test(r)&&(n=(new Date).getFullYear(),n=n.toString().slice(0,2),r=n+r),e=parseInt(e,10),r=parseInt(r,10),{month:e,year:r}},t.payment.validateCardNumber=function(t){var n,r;return t=(t+"").replace(/\s+|-/g,""),/^\d+$/.test(t)?(n=e(t),n?(r=t.length,k.call(n.length,r)>=0&&(n.luhn===!1||p(t))):!1):!1},t.payment.validateCardExpiry=function(e,n){var r,a,o;return"object"==typeof e&&"month"in e&&(o=e,e=o.month,n=o.year),e&&n?(e=t.trim(e),n=t.trim(n),/^\d+$/.test(e)&&/^\d+$/.test(n)&&e>=1&&12>=e?(2===n.length&&(n=70>n?"20"+n:"19"+n),4!==n.length?!1:(a=new Date(n,e),r=new Date,a.setMonth(a.getMonth()-1),a.setMonth(a.getMonth()+1,1),a>r)):!1):!1},t.payment.validateCardCVC=function(e,r){var a,o;return e=t.trim(e),/^\d+$/.test(e)?(a=n(r),null!=a?(o=e.length,k.call(a.cvcLength,o)>=0):e.length>=3&&e.length<=4):!1},t.payment.cardType=function(t){var n;return t?(null!=(n=e(t))?n.type:void 0)||null:null},t.payment.formatCardNumber=function(n){var r,a,o,i;return n=n.replace(/\D/g,""),(r=e(n))?(o=r.length[r.length.length-1],n=n.slice(0,o),r.format.global?null!=(i=n.match(r.format))?i.join(" "):void 0:(a=r.format.exec(n),null!=a?(a.shift(),a=t.grep(a,function(t){return t}),a.join(" ")):void 0)):n},t.payment.formatExpiry=function(t){var e,n,r,a;return(n=t.match(/^\D*(\d{1,2})(\D+)?(\d{1,4})?/))?(e=n[1]||"",r=n[2]||"",a=n[3]||"",a.length>0?r=" / ":" /"===r?(e=e.substring(0,1),r=""):2===e.length||r.length>0?r=" / ":1===e.length&&"0"!==e&&"1"!==e&&(e="0"+e,r=" / "),e+r+a):""}}).call(this);
 
-/*! Lazy Load 1.9.7 - MIT license - Copyright 2010-2015 Mika Tuupola */
-!function(a,b,c,d){var e=a(b);a.fn.lazyload=function(f){function g(){var b=0;i.each(function(){var c=a(this);if(!j.skip_invisible||c.is(":visible"))if(a.abovethetop(this,j)||a.leftofbegin(this,j));else if(a.belowthefold(this,j)||a.rightoffold(this,j)){if(++b>j.failure_limit)return!1}else c.trigger("appear"),b=0})}var h,i=this,j={threshold:0,failure_limit:0,event:"scroll",effect:"show",container:b,data_attribute:"original",skip_invisible:!1,appear:null,load:null,placeholder:"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsQAAA7EAZUrDhsAAAANSURBVBhXYzh8+PB/AAffA0nNPuCLAAAAAElFTkSuQmCC"};return f&&(d!==f.failurelimit&&(f.failure_limit=f.failurelimit,delete f.failurelimit),d!==f.effectspeed&&(f.effect_speed=f.effectspeed,delete f.effectspeed),a.extend(j,f)),h=j.container===d||j.container===b?e:a(j.container),0===j.event.indexOf("scroll")&&h.bind(j.event,function(){return g()}),this.each(function(){var b=this,c=a(b);b.loaded=!1,(c.attr("src")===d||c.attr("src")===!1)&&c.is("img")&&c.attr("src",j.placeholder),c.one("appear",function(){if(!this.loaded){if(j.appear){var d=i.length;j.appear.call(b,d,j)}a("<img />").bind("load",function(){var d=c.attr("data-"+j.data_attribute);c.hide(),c.is("img")?c.attr("src",d):c.css("background-image","url('"+d+"')"),c[j.effect](j.effect_speed),b.loaded=!0;var e=a.grep(i,function(a){return!a.loaded});if(i=a(e),j.load){var f=i.length;j.load.call(b,f,j)}}).attr("src",c.attr("data-"+j.data_attribute))}}),0!==j.event.indexOf("scroll")&&c.bind(j.event,function(){b.loaded||c.trigger("appear")})}),e.bind("resize",function(){g()}),/(?:iphone|ipod|ipad).*os 5/gi.test(navigator.appVersion)&&e.bind("pageshow",function(b){b.originalEvent&&b.originalEvent.persisted&&i.each(function(){a(this).trigger("appear")})}),a(c).ready(function(){g()}),this},a.belowthefold=function(c,f){var g;return g=f.container===d||f.container===b?(b.innerHeight?b.innerHeight:e.height())+e.scrollTop():a(f.container).offset().top+a(f.container).height(),g<=a(c).offset().top-f.threshold},a.rightoffold=function(c,f){var g;return g=f.container===d||f.container===b?e.width()+e.scrollLeft():a(f.container).offset().left+a(f.container).width(),g<=a(c).offset().left-f.threshold},a.abovethetop=function(c,f){var g;return g=f.container===d||f.container===b?e.scrollTop():a(f.container).offset().top,g>=a(c).offset().top+f.threshold+a(c).height()},a.leftofbegin=function(c,f){var g;return g=f.container===d||f.container===b?e.scrollLeft():a(f.container).offset().left,g>=a(c).offset().left+f.threshold+a(c).width()},a.inviewport=function(b,c){return!(a.rightoffold(b,c)||a.leftofbegin(b,c)||a.belowthefold(b,c)||a.abovethetop(b,c))},a.extend(a.expr[":"],{"below-the-fold":function(b){return a.belowthefold(b,{threshold:0})},"above-the-top":function(b){return!a.belowthefold(b,{threshold:0})},"right-of-screen":function(b){return a.rightoffold(b,{threshold:0})},"left-of-screen":function(b){return!a.rightoffold(b,{threshold:0})},"in-viewport":function(b){return a.inviewport(b,{threshold:0})},"above-the-fold":function(b){return!a.belowthefold(b,{threshold:0})},"right-of-fold":function(b){return a.rightoffold(b,{threshold:0})},"left-of-fold":function(b){return!a.rightoffold(b,{threshold:0})}})}(jQuery,window,document);
+/* Mulang 1.2 -  Multi Language Template Plugin -  By Robert@mondido.com - Requires JQuery to work. -*/
+function initMulang(n){var a={ignore_locale:!0};n&&(a.lang=n),$(".mulang").mulang(a)}function createLangSwitch(n){var a=$('<ul class="langswitch"></ul>'),l="";$(window.__mulang.languages).each(function(){l=window.__mulang.current===this.code?"active":"";var n=$('<a href="#" data-langcode="'+this.code+'">'+this.name+"</a>");n.addClass(l);var e=$("<li></li>");e.append(n),$(a).append(e)}),$(n).append(a),$(n).find("a").on("click",function(n){n.preventDefault,$(".langswitch .active").removeClass("active"),$(".mulang").mulang({lang:$(this).attr("data-langcode")}),$(this).addClass("active")})}!function($){var methods={init:function(n){},getCountry:function(n){var a=[{r:"(usa|united states|en_US)",c:"us",l:"en"},{r:"(austria|Ã¶sterreich|de_AT)",c:"at",l:"de"},{r:"(belgium|belgiÃ«|nl_BE)",c:"be",l:"nl"},{r:"(belgium|belgique|fr_BE)",c:"be",l:"fr"},{r:"(bulgaria|Ð‘ÑŠÐ»Ð³Ð°Ñ€Ð¸Ñ|bg_BG)",c:"bg",l:"en"},{r:"(croatia|hrvatska|hr_HR)",c:"hr",l:"en"},{r:"(czech republic|ÄeskÃ¡ republika|cs_CZ)",c:"cz",l:"en"},{r:"(cyprus|kÏÏ€ÏÎ¿Ï‚|el_CY)",c:"cy",l:"en"},{r:"(denmark|danmark|da_DK)",c:"dk",l:"da"},{r:"(estonia|eesti|et_EE)",c:"ee",l:"en"},{r:"(finland|suomi|fi_FI)",c:"fi",l:"fi"},{r:"(finland|finland|sv_FI)",c:"fi",l:"sv"},{r:"(france|france|fr_FR)",c:"fr",l:"fr"},{r:"(germany|deutschland|de_DE)",c:"de",l:"de"},{r:"(greece|eÎ»Î»Î¬Î´Î±|el_GR)",c:"gr",l:"en"},{r:"(hungary|magyarorszÃ¡g|hu_HU)",c:"hu",l:"en"},{r:"(ireland|ireland|en_IE)",c:"ie",l:"en"},{r:"(italy|italia|it_IT)",c:"it",l:"en"},{r:"(latvia|latvija|lv_LV)",c:"lv",l:"en"},{r:"(lithuania|lietuva|lt_LT)",c:"lt",l:"en"},{r:"(luxembourg|luxembourg|fr_LU)",c:"lu",l:"fr"},{r:"(luxembourg|luxemburg|de_LU)",c:"lu",l:"de"},{r:"(malta|malta|mt_MT)",c:"mt",l:"en"},{r:"(netherlands|nederland|nl_NL)",c:"nl",l:"nl"},{r:"(norway|norge|no_NO)",c:"no",l:"en"},{r:"(poland|polska|pl_PL)",c:"pl",l:"en"},{r:"(portugal|portugal|pt_PT)",c:"pt",l:"en"},{r:"(romania|romÃ¢nia|ro_RO)",c:"ro",l:"en"},{r:"(slovakia|slovensko|sk_SK)",c:"sk",l:"en"},{r:"(slovenia|slovenija|sl_SI)",c:"si",l:"en"},{r:"(spain|espaÃ±a|es_ES)",c:"es",l:"es"},{r:"(united kingdom|uk|en_GB)",c:"gb",l:"en"},{r:"(sweden|sverige|se_SE)",c:"se",l:"sv"}],l=[];return $(a).each(function(){var a=new RegExp(this.r,"gi"),e=n.match(a);e&&l.splice(e.length,0,this)}),l.length>0?l[l.length-1]:null}};$.fn.mulang=function(options){if(methods[options])return methods[options].apply(this,Array.prototype.slice.call(arguments,1));options||(options={}),options.fallback||(options.fallback="en");var do_log=function(n){window.console&&console.log(n)};if(options.lang?do_log("mulang is grabbing "+options.lang+" from options"):(options.lang=window.navigator.userLanguage||window.navigator.language,langFromData=$.fn.mulang("getCountry",options.data+" "+options.lang.replace("-","_")),langFromData&&(options.lang=langFromData.l),do_log("mulang is grabbing "+options.lang+" from browser and metadata"),options.ignore_locale&&(options.lang=options.lang.substr(0,options.lang.indexOf("-")),do_log("mulang is ignoring locale and using "+options.lang))),void 0===window.__mulang)return do_log("mulang languages file not loaded"),!1;if(!__mulang[options.lang]&&(do_log(options.lang+" is not found in mulang language file"),options.fallback&&(do_log("mulang is trying fallback language "+options.fallback),options.lang=options.fallback,!__mulang[options.lang])))return do_log(options.lang+" is not found in mulang language file"),!1;window.__mulang.current=options.lang;var find_ph=function(n){var a,l=/.*(\[.*]).*/;return null!==(a=l.exec(n))?(a.index===l.lastIndex&&l.lastIndex++,a[1]):null},contains_html=function(n){var a,l=/.*<.*>.*/;return null!==(a=l.exec(n))?!0:!1},parse_ph=function(str,arr_str){var arr=eval(arr_str);"[object Array]"!=Object.prototype.toString.call(arr)&&do_log("placeholder parameters for is not an Array ("+arr_str+")");for(var i=0;i<arr.length;i++)str=str.replace("{"+i+"}",arr[i]);return str};this.each(function(){var n=!1,a="mulang";if(void 0!==$(this).attr(a)&&(n=!0),!n&&(a="data-mulang",void 0===$(this).attr(a)))return!0;var l=$(this).attr(a),e="text",t=null;l.indexOf("[")>-1&&(t=find_ph(l),l=l.substr(0,l.indexOf("["))),l.indexOf(":")>-1&&(e=l.substr(l.indexOf(":")+1),l=l.substr(0,l.indexOf(":")));var r=__mulang[options.lang][l];void 0===r&&(r=$(this).attr(a)),null!==t&&(r=parse_ph(r,t)),"text"==e?contains_html(r)?$(this).html(r):$(this).text(r):$(this).attr(e,r)})}}(jQuery),$(".mulang").mulang({data:mondidoSettings.metadata}),createLangSwitch($("#languages"));
 
+/* mondido lib 1.1*/
+jQuery(function($) {
+  $('#mondidoPaymentTab li').hide();
 
-//https://github.com/stripe/jquery.payment - 2.0.0
-// Generated by CoffeeScript 1.7.1
-(function() {
-  var $, cardFromNumber, cardFromType, cards, defaultFormat, formatBackCardNumber, formatBackExpiry, formatCardNumber, formatExpiry, formatForwardExpiry, formatForwardSlashAndSpace, hasTextSelected, luhnCheck, reFormatCVC, reFormatCardNumber, reFormatExpiry, reFormatNumeric, replaceFullWidthChars, restrictCVC, restrictCardNumber, restrictExpiry, restrictNumeric, safeVal, setCardType,
-    __slice = [].slice,
-    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+  var tarr = [];
+  var lang = window.navigator.userLanguage || window.navigator.language;
+  if (window.navigator.languages) {
+    lang += ' ' + window.navigator.languages.toString();
+  }
+  var country = $.fn.mulang('getCountry', mondidoSettings.metadata + ' ' + lang.replace('-', '_'));
+  var tab_active = 0;
 
-  $ = window.jQuery || window.Zepto || window.$;
+  $(mondidoSettings.supportedPaymentMethods).each(function() {
+    var name = this.name;
+    var keep = false;
 
-  $.payment = {};
-
-  $.payment.fn = {};
-
-  $.fn.payment = function() {
-    var args, method;
-    method = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-    return $.payment.fn[method].apply(this, args);
-  };
-
-  defaultFormat = /(\d{1,4})/g;
-
-  $.payment.cards = cards = [
-    {
-      type: 'elo',
-      patterns: [4011, 4312, 4389, 4514, 4573, 4576, 5041, 5066, 5067, 509, 6277, 6362, 6363, 650, 6516, 6550],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'visaelectron',
-      patterns: [4026, 417500, 4405, 4508, 4844, 4913, 4917],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'maestro',
-      patterns: [5018, 502, 503, 506, 56, 58, 639, 6220, 67],
-      format: defaultFormat,
-      length: [12, 13, 14, 15, 16, 17, 18, 19],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'forbrugsforeningen',
-      patterns: [600],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'dankort',
-      patterns: [5019],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'visa',
-      patterns: [4],
-      format: defaultFormat,
-      length: [13, 16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'mastercard',
-      patterns: [51, 52, 53, 54, 55, 22, 23, 24, 25, 26, 27],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'amex',
-      patterns: [34, 37],
-      format: /(\d{1,4})(\d{1,6})?(\d{1,5})?/,
-      length: [15],
-      cvcLength: [3, 4],
-      luhn: true
-    }, {
-      type: 'dinersclub',
-      patterns: [30, 36, 38, 39],
-      format: /(\d{1,4})(\d{1,6})?(\d{1,4})?/,
-      length: [14],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'discover',
-      patterns: [60, 64, 65, 622],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }, {
-      type: 'unionpay',
-      patterns: [62, 88],
-      format: defaultFormat,
-      length: [16, 17, 18, 19],
-      cvcLength: [3],
-      luhn: false
-    }, {
-      type: 'jcb',
-      patterns: [35],
-      format: defaultFormat,
-      length: [16],
-      cvcLength: [3],
-      luhn: true
-    }
-  ];
-
-  cardFromNumber = function(num) {
-    var card, p, pattern, _i, _j, _len, _len1, _ref;
-    num = (num + '').replace(/\D/g, '');
-    for (_i = 0, _len = cards.length; _i < _len; _i++) {
-      card = cards[_i];
-      _ref = card.patterns;
-      for (_j = 0, _len1 = _ref.length; _j < _len1; _j++) {
-        pattern = _ref[_j];
-        p = pattern + '';
-        if (num.substr(0, p.length) === p) {
-          return card;
+    if (this.active) {
+      if ($.inArray('all', this.currencies) > -1 || $.inArray(mondidoSettings.currency, this.currencies) > -1) { // allowed currency
+        if ($.inArray('all', this.countries) > -1 || $.inArray(country.c, this.countries) > -1) { // allowed country
+          $('.' + name).show();
+          keep = true;
         }
       }
+      tab_active++;
     }
+
+    if (keep) {
+      tarr.push($($('.' + name)[0]).detach());
+    } else {
+      $($('.' + name)[0]).detach();
+    }
+  });
+
+  $(tarr).each(function() {
+    $('#mondidoPaymentTab').append(this);
+    this.show();
+  });
+
+  if (document.location.href.indexOf('payment.selected') > -1) {
+    var tabName = getParameterByName('payment.selected') + "_tab";
+    if ($('.' + tabName + ' a').length > 0) {
+      mondidoSettings.activePaymentMethod = tabName;
+    }
+  }
+
+  $('.' + mondidoSettings.activePaymentMethod + ' a').trigger('click');
+  $('[data-numeric]').payment('restrictNumeric');
+  $('.cc-number').payment('formatCardNumber');
+  $('.cc-cvc').payment('formatCardCVC');
+
+  $.fn.toggleInputError = function(erred) {
+    this.parent('.form-group').toggleClass('has-error', erred);
+    return this;
   };
 
-  cardFromType = function(type) {
-    var card, _i, _len;
-    for (_i = 0, _len = cards.length; _i < _len; _i++) {
-      card = cards[_i];
-      if (card.type === type) {
-        return card;
-      }
-    }
-  };
+  if ($('#mondidoPaymentTab li').length == 1) {
+    $(".text-choose-payment").addClass("hidden");
+    $("#payment-tabpanel").addClass("hidden");
+    $('#mondidoPaymentTab a:last').tab('show')
+  } else {
+    $("#mondidoPaymentTab a[href='#" + mondidoSettings.activePaymentMethod + "']").tab('show')
+  }
 
-  luhnCheck = function(num) {
-    var digit, digits, odd, sum, _i, _len;
-    odd = true;
-    sum = 0;
-    digits = (num + '').split('').reverse();
-    for (_i = 0, _len = digits.length; _i < _len; _i++) {
-      digit = digits[_i];
-      digit = parseInt(digit, 10);
-      if ((odd = !odd)) {
-        digit *= 2;
-      }
-      if (digit > 9) {
-        digit -= 9;
-      }
-      sum += digit;
-    }
-    return sum % 10 === 0;
-  };
+  ///// invoice
+  invoice = $.grep(mondidoSettings.supportedPaymentMethods, function(e) {
+    return e.name == "invoice_tab";
+  });
+  segmentation = invoice[0].segmentation;
 
-  hasTextSelected = function($target) {
-    var _ref;
-    if (($target.prop('selectionStart') != null) && $target.prop('selectionStart') !== $target.prop('selectionEnd')) {
-      return true;
+  $("#accept_collector").attr("data-mulang", "invoice_accept_conditions['" + mondidoSettings.layout.name + "','" + mondidoSettings.layout.terms_and_conditions_url + "','" + invoice[0].AgreementCode + "','" + invoice[0].AgreementCode + "']");
+
+  if (isBlank($('#segmentation').val())) {
+    set_segmentation(segmentation.defualt);
+  } else {
+    set_segmentation($('#segmentation').val());
+  }
+
+  if (invoice[0].segmentation.b2b == true && invoice[0].segmentation.b2c == true) {
+    $('#segmentation_toggle').removeClass('hidden');
+
+    $(".segmentation_select").click(function() {
+      set_segmentation($(this).attr('data-value'));
+    });
+
+  } else {
+
+    if (invoice[0].segmentation.b2c == true) {
+      $('#row-ssn-details').removeClass('hidden');
+
+      $(".invoice-input").each(function() {
+        $(this).attr('disabled', 'disabled');
+      });
+
+    } else {
+      $('#segmentation').val("b2b");
     }
-    if ((typeof document !== "undefined" && document !== null ? (_ref = document.selection) != null ? _ref.createRange : void 0 : void 0) != null) {
-      if (document.selection.createRange().text) {
+
+    $('#segmentation').addClass('hidden');
+  }
+
+  function set_segmentation(segmentation) {
+    if (segmentation == "b2c" || segmentation == "b2b") {} else {
+      segmentation = "b2c";
+    }
+
+    if (segmentation == "b2c") {
+
+      $('#b2c').addClass('btn-primary');
+      $('#b2c').removeClass('btn-secondary');
+
+      $('#b2b').removeClass('btn-primary');
+      $('#b2b').addClass('btn-secondary');
+
+    } else {
+
+      $('#b2b').addClass('btn-primary');
+      $('#b2b').removeClass('btn-secondary');
+
+      $('#b2c').removeClass('btn-primary');
+      $('#b2c').addClass('btn-secondary');
+
+    }
+
+    $('#segmentation').val(segmentation);
+
+    $('#ssn').val("");
+    $('#row-customer-details').addClass('hidden');
+
+  }
+
+  var ssn_on_load = $('#ssn').val();
+
+  if (isBlank($('#ssn').val())) {
+    $('#row-ssn-details').addClass('hidden');
+  }
+
+  var lastKey = null;
+  var loading_ssn = $("#row-ssn-details-loading");
+  var last_ssn = $('#ssn').val();
+
+  if (isBlank($('#country_code').val())) {
+
+    $('#country_code').val("swe");
+  }
+
+  function ssn_lookup(ssn_value) {
+
+
+    var ssn = ssn_value;
+    var is_test = 'true';
+    var country_code = mondidoSettings.country_code.toLowerCase();
+    var api_url = mondidoSettings.config.system.endpoint;
+
+    if (/^19/i.test(ssn) == true && country_code.toLowerCase() == "swe"){
+      ssn = ssn.slice(2);
+    }
+    if (/^20/i.test(ssn) == true && country_code.toLowerCase() == "swe"){
+      ssn = ssn.slice(2);
+    }
+
+    console.log("country_code ->" + country_code.toLowerCase());
+    console.log("ssn length ->" +ssn.length);
+    console.log( $_mondido_ssn_load_value);
+
+    if (ssn_value == $_mondido_ssn_load_value) {
+      return false;
+    }
+
+    if (country_code.toLowerCase() == "swe" && ssn.length < 10) {
+      $('#row-customer-details').addClass('hidden');
+      $('#row-ssn-details-loading').addClass('hidden');
+      console.log("lock ssn" + country_code.toLowerCase());
+      return false;
+    }
+
+
+    if (country_code.toLowerCase() != "swe") {
+      $('#row-ssn-details').removeClass('hidden');
+      $('#row-customer-details').removeClass('hidden');
+      $('#ssn').addClass('valid');
+      $('#row-ssn-details-loading').addClass('hidden');
+      ssn_on_load = 0;
+
+    } else if (isSwedishSocialSecurityNumber(ssn_on_load)) {
+      var first_name = $('#first_name').val();
+      var last_name = $('#last_name').val();
+      var zip = $('#zip').val();
+      var city = $('#city').val();
+      var address_1 = $('#address_1').val();
+
+      if (!isBlank(first_name) && !isBlank(last_name) && !isBlank(zip) && !isBlank(city) && !isBlank(address_1)) {
+        $('#row-ssn-details').removeClass('hidden');
+        $('#row-customer-details').removeClass('hidden');
+        $('#ssn').addClass('valid');
+        $('#ow-ssn-details-loading').addClass('hidden');
+        ssn_on_load = 0;
         return true;
       }
     }
-    return false;
-  };
 
-  safeVal = function(value, $target) {
-    var currPair, cursor, digit, error, last, prevPair;
-    try {
-      cursor = $target.prop('selectionStart');
-    } catch (_error) {
-      error = _error;
-      cursor = null;
-    }
-    last = $target.val();
-    $target.val(value);
-    if (cursor !== null && $target.is(":focus")) {
-      if (cursor === last.length) {
-        cursor = value.length;
-      }
-      if (last !== value) {
-        prevPair = last.slice(cursor - 1, +cursor + 1 || 9e9);
-        currPair = value.slice(cursor - 1, +cursor + 1 || 9e9);
-        digit = value[cursor];
-        if (/\d/.test(digit) && prevPair === ("" + digit + " ") && currPair === (" " + digit)) {
-          cursor = cursor + 1;
-        }
-      }
-      $target.prop('selectionStart', cursor);
-      return $target.prop('selectionEnd', cursor);
-    }
-  };
+    var ssn_url = api_url + "ssn?token=" + Mondido.token + "&transaction_id=" + Mondido.transaction.id + "&merchant_id=" + Mondido.merchant.id + "&test=" + is_test + "&ssn=" + ssn + "&country=" + country_code;
 
-  replaceFullWidthChars = function(str) {
-    var chars, chr, fullWidth, halfWidth, idx, value, _i, _len;
-    if (str == null) {
-      str = '';
-    }
-    fullWidth = '\uff10\uff11\uff12\uff13\uff14\uff15\uff16\uff17\uff18\uff19';
-    halfWidth = '0123456789';
-    value = '';
-    chars = str.split('');
-    for (_i = 0, _len = chars.length; _i < _len; _i++) {
-      chr = chars[_i];
-      idx = fullWidth.indexOf(chr);
-      if (idx > -1) {
-        chr = halfWidth[idx];
-      }
-      value += chr;
-    }
-    return value;
-  };
+    $('#row-ssn-details-loading').removeClass('hidden');
 
-  reFormatNumeric = function(e) {
-    var $target;
-    $target = $(e.currentTarget);
-    return setTimeout(function() {
-      var value;
-      value = $target.val();
-      value = replaceFullWidthChars(value);
-      value = value.replace(/\D/g, '');
-      return safeVal(value, $target);
-    });
-  };
+    if (mondidoSettings.config.development == true || $('#segmentation').val() == "b2b" || country_code.toLowerCase() != "swe") {
+      $('#row-ssn-details').removeClass('hidden');
 
-  reFormatCardNumber = function(e) {
-    var $target;
-    $target = $(e.currentTarget);
-    return setTimeout(function() {
-      var value;
-      value = $target.val();
-      value = replaceFullWidthChars(value);
-      value = $.payment.formatCardNumber(value);
-      return safeVal(value, $target);
-    });
-  };
-
-  formatCardNumber = function(e) {
-    var $target, card, digit, length, re, upperLength, value;
-    digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
-      return;
-    }
-    $target = $(e.currentTarget);
-    value = $target.val();
-    card = cardFromNumber(value + digit);
-    length = (value.replace(/\D/g, '') + digit).length;
-    upperLength = 16;
-    if (card) {
-      upperLength = card.length[card.length.length - 1];
-    }
-    if (length >= upperLength) {
-      return;
-    }
-    if (($target.prop('selectionStart') != null) && $target.prop('selectionStart') !== value.length) {
-      return;
-    }
-    if (card && card.type === 'amex') {
-      re = /^(\d{4}|\d{4}\s\d{6})$/;
-    } else {
-      re = /(?:^|\s)(\d{4})$/;
-    }
-    if (re.test(value)) {
-      e.preventDefault();
-      return setTimeout(function() {
-        return $target.val(value + ' ' + digit);
-      });
-    } else if (re.test(value + digit)) {
-      e.preventDefault();
-      return setTimeout(function() {
-        return $target.val(value + digit + ' ');
-      });
-    }
-  };
-
-  formatBackCardNumber = function(e) {
-    var $target, value;
-    $target = $(e.currentTarget);
-    value = $target.val();
-    if (e.which !== 8) {
-      return;
-    }
-    if (($target.prop('selectionStart') != null) && $target.prop('selectionStart') !== value.length) {
-      return;
-    }
-    if (/\d\s$/.test(value)) {
-      e.preventDefault();
-      return setTimeout(function() {
-        return $target.val(value.replace(/\d\s$/, ''));
-      });
-    } else if (/\s\d?$/.test(value)) {
-      e.preventDefault();
-      return setTimeout(function() {
-        return $target.val(value.replace(/\d$/, ''));
-      });
-    }
-  };
-
-  reFormatExpiry = function(e) {
-    var $target;
-    $target = $(e.currentTarget);
-    return setTimeout(function() {
-      var value;
-      value = $target.val();
-      value = replaceFullWidthChars(value);
-      value = $.payment.formatExpiry(value);
-      return safeVal(value, $target);
-    });
-  };
-
-  formatExpiry = function(e) {
-    var $target, digit, val;
-    digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
-      return;
-    }
-    $target = $(e.currentTarget);
-    val = $target.val() + digit;
-    if (/^\d$/.test(val) && (val !== '0' && val !== '1')) {
-      e.preventDefault();
-      return setTimeout(function() {
-        return $target.val("0" + val + " / ");
-      });
-    } else if (/^\d\d$/.test(val)) {
-      e.preventDefault();
-      return setTimeout(function() {
-        var m1, m2;
-        m1 = parseInt(val[0], 10);
-        m2 = parseInt(val[1], 10);
-        if (m2 > 2 && m1 !== 0) {
-          return $target.val("0" + m1 + " / " + m2);
-        } else {
-          return $target.val("" + val + " / ");
-        }
-      });
-    }
-  };
-
-  formatForwardExpiry = function(e) {
-    var $target, digit, val;
-    digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
-      return;
-    }
-    $target = $(e.currentTarget);
-    val = $target.val();
-    if (/^\d\d$/.test(val)) {
-      return $target.val("" + val + " / ");
-    }
-  };
-
-  formatForwardSlashAndSpace = function(e) {
-    var $target, val, which;
-    which = String.fromCharCode(e.which);
-    if (!(which === '/' || which === ' ')) {
-      return;
-    }
-    $target = $(e.currentTarget);
-    val = $target.val();
-    if (/^\d$/.test(val) && val !== '0') {
-      return $target.val("0" + val + " / ");
-    }
-  };
-
-  formatBackExpiry = function(e) {
-    var $target, value;
-    $target = $(e.currentTarget);
-    value = $target.val();
-    if (e.which !== 8) {
-      return;
-    }
-    if (($target.prop('selectionStart') != null) && $target.prop('selectionStart') !== value.length) {
-      return;
-    }
-    if (/\d\s\/\s$/.test(value)) {
-      e.preventDefault();
-      return setTimeout(function() {
-        return $target.val(value.replace(/\d\s\/\s$/, ''));
-      });
-    }
-  };
-
-  reFormatCVC = function(e) {
-    var $target;
-    $target = $(e.currentTarget);
-    return setTimeout(function() {
-      var value;
-      value = $target.val();
-      value = replaceFullWidthChars(value);
-      value = value.replace(/\D/g, '').slice(0, 4);
-      return safeVal(value, $target);
-    });
-  };
-
-  restrictNumeric = function(e) {
-    var input;
-    if (e.metaKey || e.ctrlKey) {
-      return true;
-    }
-    if (e.which === 32) {
-      return false;
-    }
-    if (e.which === 0) {
-      return true;
-    }
-    if (e.which < 33) {
-      return true;
-    }
-    input = String.fromCharCode(e.which);
-    return !!/[\d\s]/.test(input);
-  };
-
-  restrictCardNumber = function(e) {
-    var $target, card, digit, value;
-    $target = $(e.currentTarget);
-    digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
-      return;
-    }
-    if (hasTextSelected($target)) {
-      return;
-    }
-    value = ($target.val() + digit).replace(/\D/g, '');
-    card = cardFromNumber(value);
-    if (card) {
-      return value.length <= card.length[card.length.length - 1];
-    } else {
-      return value.length <= 16;
-    }
-  };
-
-  restrictExpiry = function(e) {
-    var $target, digit, value;
-    $target = $(e.currentTarget);
-    digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
-      return;
-    }
-    if (hasTextSelected($target)) {
-      return;
-    }
-    value = $target.val() + digit;
-    value = value.replace(/\D/g, '');
-    if (value.length > 6) {
-      return false;
-    }
-  };
-
-  restrictCVC = function(e) {
-    var $target, digit, val;
-    $target = $(e.currentTarget);
-    digit = String.fromCharCode(e.which);
-    if (!/^\d+$/.test(digit)) {
-      return;
-    }
-    if (hasTextSelected($target)) {
-      return;
-    }
-    val = $target.val() + digit;
-    return val.length <= 4;
-  };
-
-  setCardType = function(e) {
-    var $target, allTypes, card, cardType, val;
-    $target = $(e.currentTarget);
-    val = $target.val();
-    cardType = $.payment.cardType(val) || 'unknown';
-    if (!$target.hasClass(cardType)) {
-      allTypes = (function() {
-        var _i, _len, _results;
-        _results = [];
-        for (_i = 0, _len = cards.length; _i < _len; _i++) {
-          card = cards[_i];
-          _results.push(card.type);
-        }
-        return _results;
-      })();
-      $target.removeClass('unknown');
-      $target.removeClass(allTypes.join(' '));
-      $target.addClass(cardType);
-      $target.toggleClass('identified', cardType !== 'unknown');
-      return $target.trigger('payment.cardType', cardType);
-    }
-  };
-
-  $.payment.fn.formatCardCVC = function() {
-    this.on('keypress', restrictNumeric);
-    this.on('keypress', restrictCVC);
-    this.on('paste', reFormatCVC);
-    this.on('change', reFormatCVC);
-    this.on('input', reFormatCVC);
-    return this;
-  };
-
-  $.payment.fn.formatCardExpiry = function() {
-    this.on('keypress', restrictNumeric);
-    this.on('keypress', restrictExpiry);
-    this.on('keypress', formatExpiry);
-    this.on('keypress', formatForwardSlashAndSpace);
-    this.on('keypress', formatForwardExpiry);
-    this.on('keydown', formatBackExpiry);
-    this.on('change', reFormatExpiry);
-    this.on('input', reFormatExpiry);
-    return this;
-  };
-
-  $.payment.fn.formatCardNumber = function() {
-    this.on('keypress', restrictNumeric);
-    this.on('keypress', restrictCardNumber);
-    this.on('keypress', formatCardNumber);
-    this.on('keydown', formatBackCardNumber);
-    this.on('keyup', setCardType);
-    this.on('paste', reFormatCardNumber);
-    this.on('change', reFormatCardNumber);
-    this.on('input', reFormatCardNumber);
-    this.on('input', setCardType);
-    return this;
-  };
-
-  $.payment.fn.restrictNumeric = function() {
-    this.on('keypress', restrictNumeric);
-    this.on('paste', reFormatNumeric);
-    this.on('change', reFormatNumeric);
-    this.on('input', reFormatNumeric);
-    return this;
-  };
-
-  $.payment.fn.cardExpiryVal = function() {
-    return $.payment.cardExpiryVal($(this).val());
-  };
-
-  $.payment.cardExpiryVal = function(value) {
-    var month, prefix, year, _ref;
-    _ref = value.split(/[\s\/]+/, 2), month = _ref[0], year = _ref[1];
-    if ((year != null ? year.length : void 0) === 2 && /^\d+$/.test(year)) {
-      prefix = (new Date).getFullYear();
-      prefix = prefix.toString().slice(0, 2);
-      year = prefix + year;
-    }
-    month = parseInt(month, 10);
-    year = parseInt(year, 10);
-    return {
-      month: month,
-      year: year
-    };
-  };
-
-  $.payment.validateCardNumber = function(num) {
-    var card, _ref;
-    num = (num + '').replace(/\s+|-/g, '');
-    if (!/^\d+$/.test(num)) {
-      return false;
-    }
-    card = cardFromNumber(num);
-    if (!card) {
-      return false;
-    }
-    return (_ref = num.length, __indexOf.call(card.length, _ref) >= 0) && (card.luhn === false || luhnCheck(num));
-  };
-
-  $.payment.validateCardExpiry = function(month, year) {
-    var currentTime, expiry, _ref;
-    if (typeof month === 'object' && 'month' in month) {
-      _ref = month, month = _ref.month, year = _ref.year;
-    }
-    if (!(month && year)) {
-      return false;
-    }
-    month = $.trim(month);
-    year = $.trim(year);
-    if (!/^\d+$/.test(month)) {
-      return false;
-    }
-    if (!/^\d+$/.test(year)) {
-      return false;
-    }
-    if (!((1 <= month && month <= 12))) {
-      return false;
-    }
-    if (year.length === 2) {
-      if (year < 70) {
-        year = "20" + year;
-      } else {
-        year = "19" + year;
-      }
-    }
-    if (year.length !== 4) {
-      return false;
-    }
-    expiry = new Date(year, month);
-    currentTime = new Date;
-    expiry.setMonth(expiry.getMonth() - 1);
-    expiry.setMonth(expiry.getMonth() + 1, 1);
-    return expiry > currentTime;
-  };
-
-  $.payment.validateCardCVC = function(cvc, type) {
-    var card, _ref;
-    cvc = $.trim(cvc);
-    if (!/^\d+$/.test(cvc)) {
-      return false;
-    }
-    card = cardFromType(type);
-    if (card != null) {
-      return _ref = cvc.length, __indexOf.call(card.cvcLength, _ref) >= 0;
-    } else {
-      return cvc.length >= 3 && cvc.length <= 4;
-    }
-  };
-
-  $.payment.cardType = function(num) {
-    var _ref;
-    if (!num) {
-      return null;
-    }
-    return ((_ref = cardFromNumber(num)) != null ? _ref.type : void 0) || null;
-  };
-
-  $.payment.formatCardNumber = function(num) {
-    var card, groups, upperLength, _ref;
-    num = num.replace(/\D/g, '');
-    card = cardFromNumber(num);
-    if (!card) {
-      return num;
-    }
-    upperLength = card.length[card.length.length - 1];
-    num = num.slice(0, upperLength);
-    if (card.format.global) {
-      return (_ref = num.match(card.format)) != null ? _ref.join(' ') : void 0;
-    } else {
-      groups = card.format.exec(num);
-      if (groups == null) {
-        return;
-      }
-      groups.shift();
-      groups = $.grep(groups, function(n) {
-        return n;
-      });
-      return groups.join(' ');
-    }
-  };
-
-  $.payment.formatExpiry = function(expiry) {
-    var mon, parts, sep, year;
-    parts = expiry.match(/^\D*(\d{1,2})(\D+)?(\d{1,4})?/);
-    if (!parts) {
-      return '';
-    }
-    mon = parts[1] || '';
-    sep = parts[2] || '';
-    year = parts[3] || '';
-    if (year.length > 0) {
-      sep = ' / ';
-    } else if (sep === ' /') {
-      mon = mon.substring(0, 1);
-      sep = '';
-    } else if (mon.length === 2 || sep.length > 0) {
-      sep = ' / ';
-    } else if (mon.length === 1 && (mon !== '0' && mon !== '1')) {
-      mon = "0" + mon;
-      sep = ' / ';
-    }
-    return mon + sep + year;
-  };
-
-}).call(this);
-
-  /*
-    Mulang 1.2
-    Multi Language Template Plugin
-    By Robert@mondido.com
-
-    Requires JQuery to work.
-   */
-  (function ( $ ) {
-
-      var methods = {
-          init : function(options) {
-
-          },
-          getCountry : function(data) {
-          /*
-          Get estimated country from metadata and/or locale string
-          returns for example: se,us,unknown
-          */
-              var filter = [
-              {r: '(usa|united states|en_US)',c: 'us', l: 'en'},
-              {r: '(austria|Ã¶sterreich|de_AT)',c: 'at', l: 'de'},
-              {r: '(belgium|belgiÃ«|nl_BE)',c: 'be', l: 'nl'},
-              {r: '(belgium|belgique|fr_BE)',c: 'be', l: 'fr'},
-              {r: '(bulgaria|Ð‘ÑŠÐ»Ð³Ð°Ñ€Ð¸Ñ|bg_BG)',c: 'bg', l: 'en'},
-              {r: '(croatia|hrvatska|hr_HR)',c: 'hr', l: 'en'},
-              {r: '(czech republic|ÄeskÃ¡ republika|cs_CZ)',c: 'cz', l: 'en'},
-              {r: '(cyprus|kÏÏ€ÏÎ¿Ï‚|el_CY)',c: 'cy', l: 'en'},
-              {r: '(denmark|danmark|da_DK)',c: 'dk', l: 'da'},
-              {r: '(estonia|eesti|et_EE)',c: 'ee', l: 'en'},
-              {r: '(finland|suomi|fi_FI)',c: 'fi', l: 'fi'},
-              {r: '(finland|finland|sv_FI)',c: 'fi', l: 'sv'},
-              {r: '(france|france|fr_FR)',c: 'fr', l: 'fr'},
-              {r: '(germany|deutschland|de_DE)',c: 'de', l: 'de'},
-              {r: '(greece|eÎ»Î»Î¬Î´Î±|el_GR)',c: 'gr', l: 'en'},
-              {r: '(hungary|magyarorszÃ¡g|hu_HU)',c: 'hu', l: 'en'},
-              {r: '(ireland|ireland|en_IE)',c: 'ie', l: 'en'},
-              {r: '(italy|italia|it_IT)',c: 'it', l: 'en'},
-              {r: '(latvia|latvija|lv_LV)',c: 'lv', l: 'en'},
-              {r: '(lithuania|lietuva|lt_LT)',c: 'lt', l: 'en'},
-              {r: '(luxembourg|luxembourg|fr_LU)',c: 'lu', l: 'fr'},
-              {r: '(luxembourg|luxemburg|de_LU)',c: 'lu', l: 'de'},
-              {r: '(malta|malta|mt_MT)',c: 'mt', l: 'en'},
-              {r: '(netherlands|nederland|nl_NL)',c: 'nl', l: 'nl'},
-              {r: '(norway|norge|no_NO)',c: 'no', l: 'en'},
-              {r: '(poland|polska|pl_PL)',c: 'pl', l: 'en'},
-              {r: '(portugal|portugal|pt_PT)',c: 'pt', l: 'en'},
-              {r: '(romania|romÃ¢nia|ro_RO)',c: 'ro', l: 'en'},
-              {r: '(slovakia|slovensko|sk_SK)',c: 'sk', l: 'en'},
-              {r: '(slovenia|slovenija|sl_SI)',c: 'si', l: 'en'},
-              {r: '(spain|espaÃ±a|es_ES)',c: 'es', l: 'es'},
-              {r: '(united kingdom|uk|en_GB)',c: 'gb', l: 'en'},
-              {r: '(sweden|sverige|se_SE)',c: 'se', l: 'sv'}
-              ];
-              var score = [];
-              $(filter).each(function(){
-                  var regex = new RegExp(this.r,'gi');
-                  var res = data.match(regex);
-                  if(res){
-                      score.splice(res.length, 0, this);
-                  }
-              });
-              if(score.length > 0){
-                  return score[score.length-1];
-              }else{
-                  return null;
-              }
-          }
-      };
-
-
-    $.fn.mulang = function( options ) {
-
-      if ( methods[options] ) {
-          return methods[ options ].apply( this, Array.prototype.slice.call( arguments, 1 ));
-      }
-
-      if(!options){
-        options = {};
-      }
-      if(!options.fallback){
-        options.fallback = 'en';
-      }
-      var do_log = function(str){
-        if(window.console){
-          console.log(str);
-        }
-      };
-
-      if(!options.lang){ //if there is no lang in options, grab from the browser
-        options.lang = window.navigator.userLanguage || window.navigator.language;
-        langFromData = $.fn.mulang('getCountry',options.data +' '+options.lang.replace('-','_'));
-        if(langFromData){
-            options.lang = langFromData.l;
-        }
-        do_log('mulang is grabbing '+options.lang+' from browser and metadata');
-        if(options.ignore_locale){ //should we ignore locale and use ex. en for en-US
-          options.lang = options.lang.substr(0,options.lang.indexOf('-'));
-          do_log('mulang is ignoring locale and using '+options.lang);
-        }
-      }else{
-        do_log('mulang is grabbing '+options.lang+' from options');
-      }
-      //do we have text data?
-      if(window.__mulang === undefined){
-        do_log('mulang languages file not loaded');
-        return false;
-      }
-      if(!__mulang[options.lang]){
-        do_log(options.lang+' is not found in mulang language file');
-        if(options.fallback){
-          do_log('mulang is trying fallback language '+options.fallback);
-          options.lang = options.fallback;
-          if(!__mulang[options.lang]){
-            do_log(options.lang+' is not found in mulang language file');
-            return false;
-          }
-        }
-      }
-
-      window.__mulang.current = options.lang;
-
-      //find placeholder array
-      var find_ph = function(str){
-        var re = /.*(\[.*]).*/;
-        var m;
-        if ((m = re.exec(str)) !== null) {
-          if (m.index === re.lastIndex) {
-            re.lastIndex++;
-          }
-          return m[1];
-        }
-        return null;
-      };
-
-      //check if string contains html
-      var contains_html = function(str){
-        var re = /.*<.*>.*/;
-        var m;
-        if ((m = re.exec(str)) !== null) {
-          return true;
-        }
-        return false;
-      };
-
-      //replace placeholders for array values
-      var parse_ph = function(str,arr_str){
-        var arr = eval(arr_str);
-        if( Object.prototype.toString.call(arr) != '[object Array]' ) {
-          do_log('placeholder parameters for is not an Array ('+arr_str+')');
-        }
-        for(var i = 0;i< arr.length;i++){
-          str = str.replace('{'+i+'}', arr[i]);
-        }
-        return str;
-      };
-
-      //loop all elements
-      this.each(function(){
-        var found_attr = false;
-        var attr_name = 'mulang'; //old name
-
-        if($(this).attr(attr_name) !== undefined){
-          found_attr = true;
-        }
-
-        if(!found_attr){
-          attr_name = 'data-mulang';
-          if($(this).attr(attr_name) === undefined){
-            return true; //no language settings
-          }
-        }
-
-        var lang_key = $(this).attr(attr_name);
-        var attr = 'text';
-        //find array
-        var param_arr = null;
-        if(lang_key.indexOf('[') > -1){
-          param_arr = find_ph(lang_key);
-          lang_key = lang_key.substr(0,lang_key.indexOf('['));
-        }
-
-        //find attr value
-        if(lang_key.indexOf(':') > -1){
-          attr = lang_key.substr(lang_key.indexOf(':')+1);
-          lang_key = lang_key.substr(0,lang_key.indexOf(':'));
-        }
-        var txt = __mulang[options.lang][lang_key];
-        if(txt === undefined){
-          txt = $(this).attr(attr_name);
-        }
-        if(param_arr !== null){
-          txt = parse_ph(txt,param_arr);
-        }
-        if(attr=='text'){
-          if(contains_html(txt)){
-            $(this).html(txt);
-          }else{
-            $(this).text(txt);
-          }
-        }else{
-          $(this).attr(attr,txt);
-
-        }
-      });
-    };
-
-  }( jQuery ));
-
-
-  function initMulang(lang){
-      var options = {ignore_locale:true};
-      if(lang){
-          options.lang = lang
-      }
-      $('.mulang').mulang(options);
-  }
-
-  function createLangSwitch(obj){
-      var ul = $('<ul class="langswitch"></ul>');
-      var cssAttr = '';
-      $(window.__mulang.languages).each(function(){
-          if(window.__mulang.current === this.code ){
-              cssAttr = 'active';
-          }else{
-              cssAttr = '';
-          }
-          var a = $('<a href="#" data-langcode="'+this.code+'">'+this.name+'</a>');
-          a.addClass(cssAttr);
-          var li = $('<li></li>');
-          li.append(a);
-          $(ul).append(li);
-      });
-      $(obj).append(ul);
-      $(obj).find('a').on('click',function(e){
-          e.preventDefault;
-          $('.langswitch .active').removeClass('active');
-          $('.mulang').mulang({lang: $(this).attr('data-langcode')});
-          $(this).addClass('active');
-      });
-  }
-
-  $('.mulang').mulang({data: mondidoSettings.metadata});
-  createLangSwitch($('#languages'));
-
-  if(document.location.href.indexOf('declined') > -1 || document.location.href.indexOf('fail') > -1) {
-      alert($('#try-again').text().replace(/\s+/, ""));
-  }
-
-  /* mondido lib 1.1*/
-
-  jQuery(function($) {
-      $('#myTab li').hide();
-      var tarr = [];
-      var lang = window.navigator.userLanguage || window.navigator.language;
-      if(window.navigator.languages){
-          lang += ' '+window.navigator.languages.toString();
-      }
-      var country = $.fn.mulang('getCountry',mondidoSettings.metadata +' '+ lang.replace('-','_'));
-      $(mondidoSettings.supportedPaymentMethods).each(function(){
-          var name = this.name;
-          var keep = false;
-
-          if(this.active){
-              if($.inArray('all', this.currencies) > -1 || $.inArray(mondidoSettings.currency, this.currencies) > -1){ // allowed currency
-                  if($.inArray('all', this.countries) > -1 || $.inArray(country.c, this.countries) > -1){ // allowed country
-                      $('.'+name).show();
-                      keep = true;
-                  }
-              }
-          }
-
-          if(keep){
-              tarr.push($($('.'+name)[0]).detach());
-          }else{
-              $($('.'+name)[0]).detach();
-          }
-      });
-
-      $(tarr).each(function(){
-          $('#myTab').append(this);
-          this.show();
-      });
-
-      if(document.location.href.indexOf('payment.selected') > -1) {
-          var tabName = getParameterByName('payment.selected')+"_tab";
-          if($('.'+tabName+' a').length > 0){
-              mondidoSettings.activePaymentMethod = tabName;
-          }
-      }
-      $('.'+mondidoSettings.activePaymentMethod+' a').trigger('click');
-      $('[data-numeric]').payment('restrictNumeric');
-      $('.cc-number').payment('formatCardNumber');
-      $('.cc-cvc').payment('formatCardCVC');
-
-      $.fn.toggleInputError = function(erred) {
-          this.parent('.form-group').toggleClass('has-error', erred);
-          return this;
-      };
-  });
-
-  $(document).ready(function(){
-
-      invoice = $.grep(mondidoSettings.supportedPaymentMethods, function(e){ return e.name == "invoice_tab"; });
-      segmentation = invoice[0].segmentation;
-
-      if (isBlank($('#segmentation').val())){
-        set_segmentation(segmentation.defualt);
-      } else {
-        set_segmentation($('#segmentation').val());
-      }
-
-      if (invoice[0].segmentation.b2b == true && invoice[0].segmentation.b2c == true){
-        $('#segmentation_toggle').removeClass('hidden');
-
-        $( ".segmentation_select" ).click(function() {
-          set_segmentation($(this).attr('data-value'));
-        });
-
-      } else {
-
-        if (invoice[0].segmentation.b2c == true){
-          $('#row-ssn-details').removeClass('hidden');
-
-          $('#first_name').attr('disabled', 'disabled');
-          $('#last_name').attr('disabled', 'disabled');
-          $('#zip').attr('disabled', 'disabled');
-          $('#city').attr('disabled', 'disabled');
-          $('#address_1').attr('disabled', 'disabled');
-          $('#address_2').attr('disabled', 'disabled');
-        
-        } else {
-          $('#segmentation').val("b2b");
-        }
-
-        $('#segmentation').addClass('hidden');
-      }
-
-      function set_segmentation(segmentation){
-        if (segmentation == "b2c" || segmentation == "b2b"){
-        } else {
-          segmentation = "b2c";
-        }
-
-        if (segmentation == "b2c"){
-
-          $('#b2c').addClass('btn-primary');
-          $('#b2c').removeClass('btn-secondary');
-
-          $('#b2b').removeClass('btn-primary');
-          $('#b2b').addClass('btn-secondary');
-
-        } else {
-        
-          $('#b2b').addClass('btn-primary');
-          $('#b2b').removeClass('btn-secondary');
-
-          $('#b2c').removeClass('btn-primary');
-          $('#b2c').addClass('btn-secondary');
-
-        }
-        $('#segmentation').val(segmentation);
-
-        $('#ssn').val("");
-        $('#row-customer-details').addClass('hidden');
-        $('#first_name').val("");
-        $('#last_name').val("");
-        $('#zip').val("");
-        $('#city').val("");
-        $('#address_1').val("");
-        $('#address_2').val("");
-
-      }
-
-      var ssn_on_load = $('#ssn').val();
-
-      if (isBlank($('#ssn').val())){
-        $('#row-ssn-details').addClass('hidden');
-      }
-
-      var lastKey = null;
-      var loading_ssn = $("#row-ssn-details-loading");
-      var last_ssn = $('#ssn').val();
-
-      if (isBlank($('#country_code').val())){
-          $('#country_code').val("swe");
-      }
-
-      function ssn_lookup(ssn_value){
-        var api_url = mondidoSettings.config.system.endpoint;
-
-        var ssn = ssn_value;
-        var is_test = 'true';
-        var country_code = mondidoSettings.country_code;
-
-        if(country_code.toLowerCase() == "swe" && ssn.length === 12){
-          ssn = ssn.slice(2);
-        }
-
-        if ( country_code.toLowerCase() != "swe"){
-            $('#row-ssn-details').removeClass('hidden');
-            $('#row-customer-details').removeClass('hidden');
-            $('#ssn').addClass('valid');
-            $('#ow-ssn-details-loading').addClass('hidden');
-            ssn_on_load = 0;
-
-        } else if (isSwedishSocialSecurityNumber(ssn_on_load)){
-          var first_name =  $('#first_name').val();
-          var last_name = $('#last_name').val();
-          var zip = $('#zip').val();
-          var city = $('#city').val();
-          var address_1 = $('#address_1').val();
-
-          if (!isBlank(first_name) && !isBlank(last_name) && !isBlank(zip) && !isBlank(city) && !isBlank(address_1)) {
-            $('#row-ssn-details').removeClass('hidden');
-            $('#row-customer-details').removeClass('hidden');
-            $('#ssn').addClass('valid');
-            $('#ow-ssn-details-loading').addClass('hidden');
-            ssn_on_load = 0;
-            return true;
-          }
-        }
-
-      var ssn_url = api_url+"ssn?token="+Mondido.token+"&transaction_id="+Mondido.transaction.id+"&merchant_id="+Mondido.merchant.id+"&test="+is_test+"&ssn="+ssn+"&country="+country_code;
-
-      if (mondidoSettings.config.development == true || $('#segmentation').val() == "b2b"  || country_code.toLowerCase() != "swe"){
+      if ($('#segmentation').val() == "b2b" || country_code.toLowerCase() != "swe") {
         $('#row-ssn-details').removeClass('hidden');
 
-        if ($('#segmentation').val() == "b2b"  || country_code.toLowerCase() != "swe"){
+        $(".invoice-input").each(function() {
+          $(this).prop("disabled", false);
+        });
+        $('#ssn').removeClass('invalid');
+        $('#ssn').addClass('valid');
+
+      } else {
+
+        $(".invoice-input").each(function() {
+          $(this).val($(this.name).selector + " - Development").addClass('valid');
+        });
+
+        $('#pending_payment_customer').val("");
+
+        $(".invoice-input").each(function() {
+          $(this).attr('disabled', 'disabled');
+        });
+      }
+
+      $('#row-customer-details').removeClass('hidden');
+      $('#row-ssn-details-error').addClass('hidden');
+
+    } else {
+
+      $('#ssn').addClass('hidden');
+      var jqxhr = $.get(ssn_url, function() {}).done(function(address) {
+          $_mondido_ssn_load_value = ssn;
+
           $('#row-ssn-details').removeClass('hidden');
+          $('#first_name').val(address.first_name).addClass('valid');
+          $('#last_name').val(address.last_name).addClass('valid');
+          $('#zip').val(address.zip).addClass('valid');
+          $('#country_code').val(address.country).addClass('valid');
+          $('#city').val(address.city).addClass('valid');
+          $('#address_1').val(address.address_1).addClass('valid');
+          $('#address_2').val(address.address_2).addClass('valid');
+          $('#pending_payment_customer').val(address.id);
 
-          $('#first_name').removeAttr("disabled");
-          $('#last_name').removeAttr("disabled");
-          $('#zip').removeAttr("disabled");
-          $('#city').removeAttr("disabled");
-          $('#address_1').removeAttr("disabled");
-          $('#address_2').removeAttr("disabled");
-
-           $('#ssn').removeClass('invalid');
-           $('#ssn').addClass('valid');
-
-        } else {
-
-          $('#first_name').val("first_name - Development").addClass('valid');
-          $('#last_name').val("last_name - Development").addClass('valid');
-          $('#zip').val("zip - Development").addClass('valid');
-          $('#country_code').val("SWE").addClass('valid');
-          $('#city').val("city - Development").addClass('valid');
-          $('#address_1').val("address_1 - Development").addClass('valid');
-          $('#address_2').val("address_2 - Development").addClass('valid');
-          $('#pending_payment_customer').val("");
-
-          $('#first_name').attr('disabled', 'disabled');
-          $('#last_name').attr('disabled', 'disabled');
-          $('#zip').attr('disabled', 'disabled');
-          $('#city').attr('disabled', 'disabled');
-          $('#address_1').attr('disabled', 'disabled');
-          $('#address_2').attr('disabled', 'disabled');
-
-        }
+          if (address.address_2 === undefined || address.address_2 === null || isBlank(address.address_2)) {
+            $('#invoice-address-2').addClass('hidden');
+          }
 
           $('#row-customer-details').removeClass('hidden');
           $('#row-ssn-details-error').addClass('hidden');
-  
-      } else {
-    
-        var jqxhr = $.get( ssn_url, function() {
-            }).done(function(address) {
 
-              $('#row-ssn-details').removeClass('hidden');
-              $('#first_name').val(address.first_name).addClass('valid');
-              $('#last_name').val(address.last_name).addClass('valid');
-              $('#zip').val(address.zip).addClass('valid');
-              $('#country_code').val(address.country).addClass('valid');
-              $('#city').val(address.city).addClass('valid');
-              $('#address_1').val(address.address_1).addClass('valid');
-              $('#address_2').val(address.address_2).addClass('valid');
-              $('#pending_payment_customer').val(address.id);
-
-              if (address.address_2 === undefined || address.address_2 === null || isBlank(address.address_2)) {
-                $('#address_2').addClass('hidden');
-              }
-
-              $('#row-customer-details').removeClass('hidden');
-              $('#row-ssn-details-error').addClass('hidden');
-
-               $('#ssn').removeClass('invalid');
-               $('#ssn').addClass('valid');
-            })
-            .fail(function(data) {
-              loading_ssn.addClass('hidden');
-              $('#row-ssn-details-error').removeClass('hidden');
-              $('#ow-ssn-details-loading').addClass('hidden');
-              $('#ssn').addClass('invalid');
-            })
-            .always(function() {
-              if ($('#segmentation').val() == "b2c"){
-                $('#first_name').attr('disabled', 'disabled');
-                $('#last_name').attr('disabled', 'disabled');
-                $('#zip').attr('disabled', 'disabled');
-                $('#city').attr('disabled', 'disabled');
-                $('#address_1').attr('disabled', 'disabled');
-                $('#address_2').attr('disabled', 'disabled');
-              }
-            });
-        }
-      }
-
-      $('#btn-get-address').on('click',function(e){
-        var ssn=$('#ssn').val();
-        ssn_lookup(ssn);
-      });
-
-      $("#trustlyform").attr("action", $("#mondidopayform").attr("action"));
-      $("#swishform").attr("action", $("#mondidopayform").attr("action"));
-      $("#paypalform").attr("action", $("#mondidopayform").attr("action"));
-
-      $('#myTab a').click(function (e) {
-          e.preventDefault();
-          var set_payment_method = function(m){
-              $('#payment_method').val(m);
-          };
-          set_payment_method('credit_card_'); //default
-
-          if($(this).attr("href")=="#trustly_tab"){
-              set_payment_method('bank');
-              $('#trustlyform').submit();
-
-          }else if($(this).attr('href') == '#invoice_tab'){
-              set_payment_method('invoice');
-          }else if($(this).attr('href') == '#swish_tab'){
-              set_payment_method('swish');
-          }
-          $('input:enabled').blur();
-
-          $(this).tab('show');
-
-           var is_focus = false;
-           $('input:visible:enabled').each(function( i ) {
-              if (isBlank($(this).val()) && is_focus == false ) {
-                $(this).focus();
-                is_focus = true
-              }
-            });
-           if (is_focus == false){
-              $('input:visible:enabled:last').focus();
-           }
-           $("img.lazy").lazyload();
-      });
-
-      $('#myTab li[class="active"] a').trigger('click');
-
-      $.changeFocus = function(object){
-          // Enable Pay Button
-          if(object.attr("id")=="card_cvv"){
-              $("#paybtn-cc").prop("disabled", false);
-          }
-      };
-
-      // Mobile Modifications
-      if( (/iPhone|iPod|iPad|Android|BlackBerry/).test(navigator.userAgent)){
-          $("#card_number").attr("pattern","\\d*");
-      }
-
-      var current_y = parseInt((new Date()).getFullYear().toString().substr(2,2));
-      $("#card_number").keydown(function(e){
-          $("#card_number").validateCreditCard(function(result){
-              if (result.card_type) {
-                  $(".cards").removeClass("visa");
-                  $(".cards").removeClass("visa_electron");
-                  $(".cards").removeClass("electron");
-                  $(".cards").removeClass("maestro");
-                  $(".cards").removeClass("mastercard");
-                  $(".cards").removeClass("discover");
-                  $(".cards").removeClass("amex");
-
-                  $(".cards").addClass(result.card_type.name);
-                  $(".cards").addClass("active");
-              } else {
-                  $(".cards").removeClass("active");
-              }
-          });
-      });
-      $("#card_number, #expMM, #expYY, #card_cvv").focusout(function(){
-
-          // On blur, verify if field is valid
-          // If valid, add "valid" css class
-          // Else, add "invalid" css class
-          var valid = false;
-          switch($(this).attr("id")){
-            case "card_number":
-                $(this).validateCreditCard(function(result){
-                    if(result.luhn_valid && result.length_valid && result.card_accepted){
-                        $("#card_type").val(result.card_type.name);
-                        valid=true;
-                        ccvalid = true;
-                    }
-                });
-                break;
-            case "expMM":
-                expmm = parseInt($(this).val())
-                if(!isNaN(expmm)){
-                    if (expmm >= 1 && expmm <= 12){
-                        valid = true;
-                    }
-                }
-                break;
-            case "expYY":
-                expyy = parseInt($(this).val());
-                if(!isNaN(expyy)){
-                    if (expyy >= current_y && expyy <= (current_y+20)){
-                        valid = true;
-                    }
-                }
-                break;
-            case "card_cvv":
-                cvv = parseInt($(this).val());
-                if(!isNaN(cvv)){
-                    if (cvv >= 0 && cvv <= 9999){
-                        valid = true;
-                    }
-                }
-                break;
-          }
-
-          // Cleaning CSS
-          $(this).removeClass('valid');
-          $(this).removeClass('invalid');
-
-          if(valid){
-            $(this).addClass('valid');
-          } else {
-            $(this).addClass('invalid');
-          }
-      });
-
-      if (!isBlank($('#input_card_holder').val())) {
-        $('#input_card_holder').addClass("semi");
-        $('#label_card_holder').addClass("hidden");
-      }
-
-      $('#swishform').submit(function(e){
-          sn = $('#swish_number').val();
-          sn = sn.replace(/[^0-9.]/g, "");
-
-          if(sn.substr(0,2) != '46'){
-              sn = sn.substring(1);
-              sn = '46'+sn;
-          }
-
-          if(sn.length < 5){
-            $('#swish_number').removeClass('valid');
-            $('#swish_number').addClass('invalid');
-            return false;
-          }else{
-            $('#swish_number').removeClass('invalid');
-            $('#swish_number').addClass('valid');
-          }
-
-          $('#swish_number').val(sn);
-      });
-
-      $('#invoiceform').submit(function(e){
-          if($('#accept')[0].checked == false){
-              alert('Du behÃ¶ver godkÃ¤nna villkoren.');
-              return false;
-              }
-              return true;
-      });
-
-
-      $('#mondidopayform').submit(function(e){
-        var errString = $("#validation-error").text()+"\n";
-
-        $.errFields = Array();
-        $("#card_number, #expMM, #expYY, #card_cvv").each(function(){
-            if(!$(this).hasClass("valid")){
-                $.errFields.push($(this).attr("placeholder"));
-            }
-        });
-        errString = errString + $.errFields.join(", ");
-
-        if($.errFields.length > 0 && $("#trustly1").length===0){
-            $("#errors").html(errString);
-            $("#errors").show();
-
-            $('#paybtn-cc').show();
-            $('#loading-cc').addClass('hidden');
-            $('.footer').show();
-            return false;
-        }
-
-        $("#card_expiry").val(
-            $("#expMM").val() + $("#expYY").val()
-        );
-
-        $("#errors").hide();
-        return true;
-      });
-
-      var errMsg = getParameterByName('error_name');
-      if(errMsg){
-        switch(errMsg){
-          case 'errors.personal_number.missing':
-              alert('personnummer saknas');
-              break;
-          case 'errors.missing_or_invalid.phone_number':
-              alert('Telefonnummer saknas');
-              break;
-          case 'errors.invalid.email':
-              alert('E-post Ã¤r inte korrekt');
-              break;
-          case 'errors.invoice.credit_approval_failed':
-              alert('Kreditypplysningen misslyckades');
-              break;
-          case 'errors.invoice.credit_not_approved':
-              alert('Kreditupplysningen nekades');
-              break;
-          case 'errors.invoice.amount.requested.lower_than_minimum_purchase_amount':
-              alert('Beloppet Ã¤r fÃ¶r lÃ¥gt fÃ¶r fakturabetalning');
-              break;
-          case 'errors.invoice.amount.requested.higher_than_maximum_purchase_amount':
-              alert('Beloppet Ã¤r fÃ¶r hÃ¶gt fÃ¶r fakturabetalning');
-              break;
-          case 'errors.invoice.account_error':
-              alert('Fakturakontot Ã¤r felinstÃ¤llt');
-              break;
-          case 'errors.invoice.account_was_overdrawn':
-              alert('Kontot Ã¤r Ã¶vertrasserat');
-              break;
-          default:
-              break;
-        }
-      }
-
-      function input_change() {
-          if (this.id === 'email') {
-          if (validate_email(this.value)){
-              $("#row-phone-details").removeClass('hidden');
-          }
-          }
-
-          if (this.id === 'phone') {
-          if (validate_phone(this.value)){
-              $("#row-ssn-details").removeClass('hidden');
-          }
-          }
-
-          if (this.id === 'ssn'){
-          if (isSwedishSocialSecurityNumber(this.value)){
-              ///$('#row-ssn-details-loading').removeClass('hidden');
-              ssn_lookup(this.value);
-          }
-          }
-      }
-
-      $(function() {
-        $(':input').change(input_change).keyup(input_change);
-      });
-
-      function isSwedishSocialSecurityNumber(ssn){
-        valid = false;
-
-        if (mondidoSettings.country_code.toLowerCase() != "swe"){
-
-          if (ssn.length == 12){
-            valid = true;
-            $('#row-customer-details').addClass('hidden');
-          }
-        } else {
-          valid = /^(\d{6}|\d{8})[-|(\s)]{0,1}\d{4}$/.test(ssn);
-          if (!valid){
-            $('#row-customer-details').addClass('hidden');
-          }
-        }
-
-        return valid;
-      }
-
-      /// ON LOAD
-      if (validate_email($('#email').val())) {
-          $("#row-phone-details").removeClass('hidden');
-      }
-
-      if (validate_phone($('#phone').val())) {
-          $("#row-ssn-details").removeClass('hidden');
-      }
-
-      if (isSwedishSocialSecurityNumber($('#ssn').val())) {
-          ssn_lookup($('#ssn').val());
-      }
-
-      $(document).ajaxStart(function () {
-          loading_ssn.removeClass('hidden');
-      });
-
-      $(document).ajaxStop(function () {
+          $('#row-ssn-details-loading').addClass('hidden');
+          $('#row-ssn-details-error').addClass('hidden');
+          $('#ssn').removeClass('hidden');
+          $('#ssn').removeClass('invalid');
+          $('#ssn').addClass('valid');
+        })
+        .fail(function(data) {
           loading_ssn.addClass('hidden');
-      });
+          $('#row-ssn-details-error').removeClass('hidden');
+          $('#ow-ssn-details-loading').addClass('hidden');
+          $('#ssn').addClass('invalid');
+          $('#ssn').removeClass('hidden');
+        })
+        .done(function() {
+          $_mondido_ssn_load_value = "";
+          $('#ssn').removeClass('hidden');
+          $('#row-ssn-details-loading').addClass('hidden');
+        })
+        .always(function() {
+          if ($('#segmentation').val() == "b2c") {
+
+            $(".invoice-input").each(function() {
+              $(this).attr('disabled', 'disabled');
+            });
+
+          }
+        });
+    }
+  }
+
+  $("#trustlyform").attr("action", $("#mondidopayform").attr("action"));
+  $("#swishform").attr("action", $("#mondidopayform").attr("action"));
+  $("#paypalform").attr("action", $("#mondidopayform").attr("action"));
+
+  $('#mondidoPaymentTab a').click(function(e) {
+    e.preventDefault();
+    var set_payment_method = function(m) {
+      $('#payment_method').val(m);
+    };
+    set_payment_method('credit_card_'); //default
+
+    if ($(this).attr("href") == "#trustly_tab") {
+      set_payment_method('bank');
+      $('#trustlyform').submit();
+
+    } else if ($(this).attr('href') == '#invoice_tab') {
+      set_payment_method('invoice');
+    } else if ($(this).attr('href') == '#swish_tab') {
+      set_payment_method('swish');
+    }
+    $('input:enabled').blur();
+
+    $(this).tab('show');
+
+    var is_focus = false;
+    $('input:visible:enabled').each(function(i) {
+      if (isBlank($(this).val()) && is_focus == false) {
+        $(this).focus();
+        is_focus = true
+      }
+    });
+    if (is_focus == false) {
+      $('input:visible:enabled:last').focus();
+    }
   });
 
-  function validate_email(email) {
-      var regex = /^([a-zA-Z0-9_\.\-\+])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
-      if(!regex.test(email)) {
-          if (isBlank(email)) {
-            $('#email').removeClass('valid');
-            $('#email').removeClass('invalid');
-          } else {
-            $('#email').addClass('invalid');
-          }
-          return false;
+  $('#mondidoPaymentTab li[class="active"] a').trigger('click');
+
+  $.changeFocus = function(object) {
+    // Enable Pay Button
+    if (object.attr("id") == "card_cvv") {
+      $("#paybtn-cc").prop("disabled", false);
+    }
+  };
+
+  // Mobile Modifications
+  if ((/iPhone|iPod|iPad|Android|BlackBerry/).test(navigator.userAgent)) {
+    $("#card_number").attr("pattern", "\\d*");
+  }
+
+  var current_y = parseInt((new Date()).getFullYear().toString().substr(2, 2));
+  $("#card_number").keydown(function(e) {
+    $("#card_number").validateCreditCard(function(result) {
+      $(".cards").show();
+      if (result.card_type) {
+        $(".cards").removeClass("visa");
+        $(".cards").removeClass("visa_electron");
+        $(".cards").removeClass("electron");
+        $(".cards").removeClass("maestro");
+        $(".cards").removeClass("mastercard");
+        $(".cards").removeClass("discover");
+        $(".cards").removeClass("amex");
+
+        $(".cards").addClass(result.card_type.name);
+        $(".cards").addClass("active");
       } else {
-            $('#email').addClass('valid');
-          return true;
+        $(".cards").hide();
+        $(".cards").removeClass("active");
       }
+    });
+  });
+
+  $("#card_number, #expMM, #expYY, #card_cvv").focusout(function() {
+
+    // On blur, verify if field is valid
+    // If valid, add "valid" css class
+    // Else, add "invalid" css class
+    var valid = false;
+    switch ($(this).attr("id")) {
+      case "card_number":
+        $(this).validateCreditCard(function(result) {
+          if (result.luhn_valid && result.length_valid && result.card_accepted) {
+            $("#card_type").val(result.card_type.name);
+            valid = true;
+            ccvalid = true;
+          }
+        });
+        break;
+      case "expMM":
+        expmm = parseInt($(this).val())
+        if (!isNaN(expmm)) {
+          if (expmm >= 1 && expmm <= 12) {
+            valid = true;
+          }
+        }
+        break;
+      case "expYY":
+        expyy = parseInt($(this).val());
+        if (!isNaN(expyy)) {
+          if (expyy >= current_y && expyy <= (current_y + 20)) {
+            valid = true;
+          }
+        }
+        break;
+      case "card_cvv":
+        cvv = parseInt($(this).val());
+        if (!isNaN(cvv)) {
+          if (cvv >= 0 && cvv <= 9999) {
+            valid = true;
+          }
+
+        }
+        if (cvv == 0) {
+          $(this).removeClass('invalid');
+        }
+        break;
+    }
+
+    // Cleaning CSS
+    $(this).removeClass('valid');
+    $(this).removeClass('invalid');
+
+    if (valid) {
+      $(this).addClass('valid');
+    } else {
+      if (isEmpty($(this).val())) {
+        $(this).removeClass('valid');
+        $(this).removeClass('invalid');
+
+      } else {
+        $(this).addClass('invalid');
+      }
+    }
+  });
+
+  if (!isBlank($('#input_card_holder').val())) {
+    $('#input_card_holder').addClass("semi");
+    $('#label_card_holder').addClass("hidden");
   }
 
-  function isEmpty(s){
-    return !s.length;
-  }
+  $('#swishform').submit(function(e) {
+    sn = $('#swish_number').val();
+    sn = sn.replace(/[^0-9.]/g, "");
 
-  function isBlank(s){
-    if(s){
-      return isEmpty(s.trim());
+    if (sn.substr(0, 2) != '46') {
+      sn = sn.substring(1);
+      sn = '46' + sn;
+    }
+
+    if (sn.length < 5) {
+      $('#swish_number').removeClass('valid');
+      $('#swish_number').addClass('invalid');
+      return false;
+    } else {
+      $('#swish_number').removeClass('invalid');
+      $('#swish_number').addClass('valid');
+    }
+
+    $('#swish_number').val(sn);
+  });
+
+  $('#invoiceform').submit(function(e) {
+    if ($('#accept')[0].checked == false) {
+      alert('Du behÃ¶ver godkÃ¤nna villkoren.');
+      return false;
     }
     return true;
+  });
+
+
+  $('#mondidopayform').submit(function(e) {
+    var errString = $("#validation-error").text() + "\n";
+
+    $.errFields = Array();
+    $("#card_number, #expMM, #expYY, #card_cvv").each(function() {
+      if (!$(this).hasClass("valid")) {
+        $.errFields.push($(this).attr("placeholder"));
+      }
+    });
+    errString = errString + $.errFields.join(", ");
+
+    if ($.errFields.length > 0 && $("#trustly1").length === 0) {
+      $("#errors").html(errString);
+      $("#errors").show();
+
+      $('#paybtn-cc').show();
+      $('#loading-cc').addClass('hidden');
+      $('.footer').show();
+      return false;
+    }
+
+    $("#card_expiry").val(
+      $("#expMM").val() + $("#expYY").val()
+    );
+
+    $("#errors").hide();
+    return true;
+  });
+
+  var errMsg = getParameterByName('error_name');
+  if (errMsg) {
+    switch (errMsg) {
+      case 'errors.personal_number.missing':
+        alert('personnummer saknas');
+        break;
+      case 'errors.missing_or_invalid.phone_number':
+        alert('Telefonnummer saknas');
+        break;
+      case 'errors.invalid.email':
+        alert('E-post Ãr inte korrekt');
+        break;
+      case 'errors.invoice.credit_approval_failed':
+        alert('Kreditypplysningen misslyckades');
+        break;
+      case 'errors.invoice.credit_not_approved':
+        alert('Kreditupplysningen nekades');
+        break;
+      case 'errors.invoice.amount.requested.lower_than_minimum_purchase_amount':
+        alert('Beloppet är för lågt för fakturabetalning');
+        break;
+      case 'errors.invoice.amount.requested.higher_than_maximum_purchase_amount':
+        alert('Beloppet är för högt för fakturabetalning');
+        break;
+      case 'errors.invoice.account_error':
+        alert('Fakturakontot är felinställt');
+        break;
+      case 'errors.invoice.account_was_overdrawn':
+        alert('Kontot är övertrasserat');
+        break;
+      default:
+        break;
+    }
   }
 
-  function validate_phone(phone_number){
-    valid = ((phone_number.length >= 8) && (phone_number.length <= 11));
-    if (valid){
-        $('#phone').addClass('valid');
+  function input_change() {
+    if (this.id === 'email') {
+      if (validate_email(this.value)) {
+        $("#row-phone-details").removeClass('hidden');
+      }
+    }
+
+    if (this.id === 'phone') {
+      if (validate_phone(this.value)) {
+        $("#row-ssn-details").removeClass('hidden');
+      }
+    }
+
+    if (this.id === 'ssn') {
+      if (isSwedishSocialSecurityNumber(this.value)) {
+        ssn_lookup(this.value, ssn_lookup);
+      }
+    }
+  }
+
+  $(function() {
+    $(':input').change(input_change).keyup(input_change);
+  });
+
+  function isSwedishSocialSecurityNumber(ssn) {
+    valid = false;
+
+    if (mondidoSettings.country_code.toLowerCase() != "swe") {
+
+      if (ssn.length == 12) {
+        valid = true;
+        $('#row-customer-details').addClass('hidden');
+      }
     } else {
-        if (isBlank(phone_number)) {
-        $('#phone').removeClass('valid');
-        $('#phone').removeClass('invalid');
-        } else {
-        $('#phone').addClass('invalid');
-        }
+      valid = /^(\d{6}|\d{8})[-|(\s)]{0,1}\d{4}$/.test(ssn);
+      if (!valid) {
+        $('#row-customer-details').addClass('hidden');
+      }
     }
 
     return valid;
   }
 
-  function getParameterByName(name) {
-      name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
-      var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
-              results = regex.exec(location.search);
+  /// ON LOAD
+  if (validate_email($('#email').val())) {
+    $("#row-phone-details").removeClass('hidden');
+  }
+
+  if (validate_phone($('#phone').val())) {
+    $("#row-ssn-details").removeClass('hidden');
+  }
+
+  if (isSwedishSocialSecurityNumber($('#ssn').val())) {
+    ssn_lookup($('#ssn').val(), ssn_lookup);
+  }
+
+  $(document).ajaxStart(function() {
+    loading_ssn.removeClass('hidden');
+  });
+
+  $(document).ajaxStop(function() {
+    loading_ssn.addClass('hidden');
+  });
+});
+
+function validate_email(email) {
+  var regex = /^([a-zA-Z0-9_\.\-\+])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+  if (!regex.test(email)) {
+    if (isBlank(email)) {
+      $('#email').removeClass('valid');
+      $('#email').removeClass('invalid');
+    } else {
+      $('#email').addClass('invalid');
+    }
+    return false;
+  } else {
+    $('#email').addClass('valid');
+    return true;
+  }
+}
+
+function isEmpty(s) {
+  return !s.length;
+}
+
+function isBlank(s) {
+  if (s) {
+    return isEmpty(s.trim());
+  }
+  return true;
+}
+
+function validate_phone(phone_number) {
+  if (phone_number == null) {
+    return false
+  }
+
+  valid = ((phone_number.length >= 8) && (phone_number.length <= 11));
+  if (valid) {
+    $('#phone').addClass('valid');
+  } else {
+    if (isBlank(phone_number)) {
+      $('#phone').removeClass('valid');
+      $('#phone').removeClass('invalid');
+    } else {
+      $('#phone').addClass('invalid');
+    }
+  }
+
+  return valid;
+}
+
+function getParameterByName(name) {
+  name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+  var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+    results = regex.exec(location.search);
   return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
-  }
+}
 
-  function canceled(){
-      alert($('#try-again').text());
-      $("#errors").hide();
-      $('.card-tab').tab('show');
-  }
+function canceled() {
+  alert($('#try-again').text());
+  $("#errors").hide();
+  $('.card-tab').tab('show');
+}
 
-  // payment card scripts
-  (function() {
-      var $,
-          __indexOf = [].indexOf || function(item) {
-              for (var i = 0, l = this.length; i < l; i++) {
-                  if (i in this && this[i] === item) return i;
-              }
-              return -1;
-          };
-
-      $ = jQuery;
-      $.fn.validateCreditCard = function(callback, options) {
-          var card, card_type, card_types, get_card_type, is_card_accepted, is_valid_length, is_valid_luhn, normalize, validate, validate_number, _i, _len, _ref, _ref1;
-          card_types = [{
-              name: 'amex',
-              pattern: /^3[47]/,
-              valid_length: [15]
-          }, {
-              name: 'diners',
-              pattern: /^30[0-5]/,
-              valid_length: [14]
-          }, {
-              name: 'diners',
-              pattern: /^36/,
-              valid_length: [14]
-          }, {
-              name: 'jcb',
-              pattern: /^35(2[89]|[3-8][0-9])/,
-              valid_length: [16]
-          }, {
-              name: 'laser',
-              pattern: /^(6304|670[69]|6771)/,
-              valid_length: [16, 17, 18, 19]
-          }, {
-              name: 'electron',
-              pattern: /^(4026|417500|4508|4844|491(3|7))/,
-              valid_length: [16]
-          }, {
-              name: 'visa',
-              pattern: /^4/,
-              valid_length: [16, 13]
-          }, {
-              name: 'mastercard',
-              pattern: /^5[1-5]/,
-              valid_length: [16]
-          }, {
-              name: 'maestro',
-              pattern: /^(5018|5020|5038|6304|6759|676[1-3])/,
-              valid_length: [12, 13, 14, 15, 16, 17, 18, 19]
-          }, {
-              name: 'discover',
-              pattern: /^(6011|622(12[6-9]|1[3-9][0-9]|[2-8][0-9]{2}|9[0-1][0-9]|92[0-5]|64[4-9])|65)/,
-              valid_length: [16]
-          }];
-          if (options == null) {
-              options = {};
-          }
-          if ((_ref = options.accept) == null) {
-              options.accept = (function() {
-                  var _i, _len, _results;
-                  _results = [];
-                  for (_i = 0, _len = card_types.length; _i < _len; _i++) {
-                      card = card_types[_i];
-                      _results.push(card.name);
-                  }
-                  return _results;
-              })();
-          }
-          _ref1 = options.accept;
-          for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-              card_type = _ref1[_i];
-              if (__indexOf.call((function() {
-                      var _j, _len1, _results;
-                      _results = [];
-                      for (_j = 0, _len1 = card_types.length; _j < _len1; _j++) {
-                          card = card_types[_j];
-                          _results.push(card.name);
-                      }
-                      return _results;
-                  })(), card_type) < 0) {
-                  throw "Credit card type '" + card_type + "' is not supported";
-              }
-          }
-          get_card_type = function(number) {
-              var _j, _len1, _ref2;
-              _ref2 = (function() {
-                  var _k, _len1, _ref2, _results;
-                  _results = [];
-                  for (_k = 0, _len1 = card_types.length; _k < _len1; _k++) {
-                      card = card_types[_k];
-                      if (_ref2 = card.name, __indexOf.call(options.accept, _ref2) >= 0) {
-                          _results.push(card);
-                      }
-                  }
-                  return _results;
-              })();
-              for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
-                  card_type = _ref2[_j];
-                  if (number.match(card_type.pattern)) {
-                      return card_type;
-                  }
-              }
-              return null;
-          };
-          is_valid_luhn = function(number) {
-              var digit, n, sum, _j, _len1, _ref2;
-              sum = 0;
-              _ref2 = number.split('').reverse();
-              for (n = _j = 0, _len1 = _ref2.length; _j < _len1; n = ++_j) {
-                  digit = _ref2[n];
-                  digit = +digit;
-                  if (n % 2) {
-                      digit *= 2;
-                      if (digit < 10) {
-                          sum += digit;
-                      } else {
-                          sum += digit - 9;
-                      }
-                  } else {
-                      sum += digit;
-                  }
-              }
-              return sum % 10 === 0;
-          };
-          is_valid_length = function(number, card_type) {
-              var _ref2;
-              return _ref2 = number.length, __indexOf.call(card_type.valid_length, _ref2) >= 0;
-          };
-          is_card_accepted = function(card_type) {
-              var brand = card_type.name;
-              var rule = mondidoSettings.supportedCards[brand];
-
-              if(rule && rule.active){
-                  if(rule.currencies.indexOf('all') > -1 || rule.currencies.indexOf(mondidoSettings.currency.toLowerCase()) > -1){
-                      return true;
-                  }
-              }
-              return false;
-          };
-          validate_number = function(number) {
-              var length_valid, luhn_valid, card_accepted;
-              card_type = get_card_type(number);
-              luhn_valid = false;
-              length_valid = false;
-              if (card_type != null) {
-                  luhn_valid = is_valid_luhn(number);
-                  length_valid = is_valid_length(number, card_type);
-                  card_accepted = is_card_accepted(card_type);
-              }
-              return callback({
-                  card_type: card_type,
-                  luhn_valid: luhn_valid,
-                  length_valid: length_valid,
-                  card_accepted: card_accepted
-              });
-          };
-          validate = function() {
-              var number;
-              number = normalize($(this).val());
-              return validate_number(number);
-          };
-          normalize = function(number) {
-              return number.replace(/[ -]/g, '');
-          };
-          this.bind('input', function() {
-              $(this).unbind('keyup');
-              return validate.call(this);
-          });
-          this.bind('keyup', function() {
-              return validate.call(this);
-          });
-          if (this.length !== 0) {
-              validate.call(this);
-          }
-          return this;
-      };
-
-  }).call(this);
-
-  var ccvalid = false;
-  var cardholdervalid = false;
-  var cardcvvvalid = false;
-  var cardexpiryvaid = false;
-  String.prototype.endsWith = function(suffix) {
-      return this.indexOf(suffix, this.length - suffix.length) !== -1;
-  };
-  String.prototype.removeEnd = function(s) {
-      if (this.endsWith(s)) {
-          return this.substring(0, this.length - s.length);
+// payment card scripts
+(function() {
+  var $,
+    __indexOf = [].indexOf || function(item) {
+      for (var i = 0, l = this.length; i < l; i++) {
+        if (i in this && this[i] === item) return i;
       }
-      return this;
+      return -1;
+    };
+
+  $ = jQuery;
+  $.fn.validateCreditCard = function(callback, options) {
+    var card, card_type, card_types, get_card_type, is_card_accepted, is_valid_length, is_valid_luhn, normalize, validate, validate_number, _i, _len, _ref, _ref1;
+    card_types = [{
+      name: 'amex',
+      pattern: /^3[47]/,
+      valid_length: [15]
+    }, {
+      name: 'diners',
+      pattern: /^30[0-5]/,
+      valid_length: [14]
+    }, {
+      name: 'diners',
+      pattern: /^36/,
+      valid_length: [14]
+    }, {
+      name: 'jcb',
+      pattern: /^35(2[89]|[3-8][0-9])/,
+      valid_length: [16]
+    }, {
+      name: 'laser',
+      pattern: /^(6304|670[69]|6771)/,
+      valid_length: [16, 17, 18, 19]
+    }, {
+      name: 'electron',
+      pattern: /^(4026|417500|4508|4844|491(3|7))/,
+      valid_length: [16]
+    }, {
+      name: 'visa',
+      pattern: /^4/,
+      valid_length: [16, 13]
+    }, {
+      name: 'mastercard',
+      pattern: /^5[1-5]/,
+      valid_length: [16]
+    }, {
+      name: 'maestro',
+      pattern: /^(5018|5020|5038|6304|6759|676[1-3])/,
+      valid_length: [12, 13, 14, 15, 16, 17, 18, 19]
+    }, {
+      name: 'discover',
+      pattern: /^(6011|622(12[6-9]|1[3-9][0-9]|[2-8][0-9]{2}|9[0-1][0-9]|92[0-5]|64[4-9])|65)/,
+      valid_length: [16]
+    }];
+    if (options == null) {
+      options = {};
+    }
+    if ((_ref = options.accept) == null) {
+      options.accept = (function() {
+        var _i, _len, _results;
+        _results = [];
+        for (_i = 0, _len = card_types.length; _i < _len; _i++) {
+          card = card_types[_i];
+          _results.push(card.name);
+        }
+        return _results;
+      })();
+    }
+    _ref1 = options.accept;
+    for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
+      card_type = _ref1[_i];
+      if (__indexOf.call((function() {
+          var _j, _len1, _results;
+          _results = [];
+          for (_j = 0, _len1 = card_types.length; _j < _len1; _j++) {
+            card = card_types[_j];
+            _results.push(card.name);
+          }
+          return _results;
+        })(), card_type) < 0) {
+        throw "Credit card type '" + card_type + "' is not supported";
+      }
+    }
+    get_card_type = function(number) {
+      var _j, _len1, _ref2;
+      _ref2 = (function() {
+        var _k, _len1, _ref2, _results;
+        _results = [];
+        for (_k = 0, _len1 = card_types.length; _k < _len1; _k++) {
+          card = card_types[_k];
+          if (_ref2 = card.name, __indexOf.call(options.accept, _ref2) >= 0) {
+            _results.push(card);
+          }
+        }
+        return _results;
+      })();
+      for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
+        card_type = _ref2[_j];
+        if (number.match(card_type.pattern)) {
+          return card_type;
+        }
+      }
+      return null;
+    };
+    is_valid_luhn = function(number) {
+      var digit, n, sum, _j, _len1, _ref2;
+      sum = 0;
+      _ref2 = number.split('').reverse();
+      for (n = _j = 0, _len1 = _ref2.length; _j < _len1; n = ++_j) {
+        digit = _ref2[n];
+        digit = +digit;
+        if (n % 2) {
+          digit *= 2;
+          if (digit < 10) {
+            sum += digit;
+          } else {
+            sum += digit - 9;
+          }
+        } else {
+          sum += digit;
+        }
+      }
+      return sum % 10 === 0;
+    };
+    is_valid_length = function(number, card_type) {
+      var _ref2;
+      return _ref2 = number.length, __indexOf.call(card_type.valid_length, _ref2) >= 0;
+    };
+    is_card_accepted = function(card_type) {
+      var brand = card_type.name;
+      var rule = mondidoSettings.supportedCards[brand];
+
+      if (rule && rule.active) {
+        if (rule.currencies.indexOf('all') > -1 || rule.currencies.indexOf(mondidoSettings.currency.toLowerCase()) > -1) {
+          return true;
+        }
+      }
+      return false;
+    };
+    validate_number = function(number) {
+      var length_valid, luhn_valid, card_accepted;
+      card_type = get_card_type(number);
+      luhn_valid = false;
+      length_valid = false;
+      if (card_type != null) {
+        luhn_valid = is_valid_luhn(number);
+        length_valid = is_valid_length(number, card_type);
+        card_accepted = is_card_accepted(card_type);
+      }
+      return callback({
+        card_type: card_type,
+        luhn_valid: luhn_valid,
+        length_valid: length_valid,
+        card_accepted: card_accepted
+      });
+    };
+    validate = function() {
+      var number;
+      number = normalize($(this).val());
+      return validate_number(number);
+    };
+    normalize = function(number) {
+      return number.replace(/[ -]/g, '');
+    };
+    this.bind('input', function() {
+      $(this).unbind('keyup');
+      return validate.call(this);
+    });
+    this.bind('keyup', function() {
+      return validate.call(this);
+    });
+    if (this.length !== 0) {
+      validate.call(this);
+    }
+    return this;
   };
 
-  (function() {
+}).call(this);
 
-      $('#mondidopayform').on('submit', function() {
-          var checks = true;
-          var errString = $('#validation-error').text().replace(/\s+/, "");
-          var eventName = 'keyup';
-          $('input[name="card_number"]').trigger(eventName);
-          $('input[name="card_holder"]').trigger('keydown');
-          $('input[name="card_cvv"]').trigger('keydown');
-          $('input[name="expMM"], input[name="expYY"]').trigger('change');
+var ccvalid = false;
+var cardholdervalid = false;
+var cardcvvvalid = false;
+var cardexpiryvaid = false;
+String.prototype.endsWith = function(suffix) {
+  return this.indexOf(suffix, this.length - suffix.length) !== -1;
+};
+String.prototype.removeEnd = function(s) {
+  if (this.endsWith(s)) {
+    return this.substring(0, this.length - s.length);
+  }
+  return this;
+};
 
-          $('input[name="card_number"]').removeClass('not-valid');
-          $('input[name="card_holder"]').removeClass('invalid');
-          $('input[name="card_cvv"]').removeClass('not-valid');
-          $('input[name="expMM"], input[name="expYY"]').removeClass('not-valid');
+(function() {
 
-          if (!ccvalid) {
-              errString += $('#err_cardnumber').text().replace(/\s+/, "")+', ';
-                  $('input[name="card_number"]').addClass('not-valid');
-              checks = false;
-          }
-          if (!cardholdervalid) {
-              errString += $('#err_cardholder').text().replace(/\s+/, "")+', ';
-              checks = false;
-              $('input[name="card_holder"]').addClass('invalid');
-          }
-          if (!cardcvvvalid) {
-              errString += $('#err_cvv').text().replace(/\s+/, "")+', ';
-              checks = false;
-              $('input[name="card_cvv"]').addClass('not-valid');
-          }
-          if (!cardexpiryvaid) {
-              errString += $('#err_expiry').text().replace(/\s+/, "");
-              checks = false;
-              $('input[name="expMM"], input[name="expYY"]').addClass('not-valid');
-          }
-          if (!checks) {
-              $('#paybtn-cc').show();
-              $('#loading-cc').addClass('hidden');
+  $('#mondidopayform').on('submit', function() {
+    var checks = true;
+    var errString = $('#validation-error').text().replace(/\s+/, "");
+    var eventName = 'keyup';
+    $('input[name="card_number"]').trigger(eventName);
+    $('input[name="card_holder"]').trigger('keydown');
+    $('input[name="card_cvv"]').trigger('keydown');
+    $('input[name="expMM"], input[name="expYY"]').trigger('change');
 
-              alert(errString.removeEnd(', '));
-              return false;
-          }else{
-              $('#paybtn-cc').hide();
-              $('#loading-cc').removeClass('hidden');
-          }
-          return true;
-      });
+    $('input[name="card_number"]').removeClass('not-valid');
+    $('input[name="card_holder"]').removeClass('invalid');
+    $('input[name="card_cvv"]').removeClass('not-valid');
+    $('input[name="expMM"], input[name="expYY"]').removeClass('not-valid');
 
-      $('input[name="card_number"]').validateCreditCard(function(result) {
-          if(result && result.card_type != null){
-              var text = $('#badcard').text();
-              text = text.replace('{card}',result.card_type.name.toUpperCase());
-              $('.arrow_box').text(text);
-          }
-          if (result.length_valid && result.luhn_valid && result.card_accepted) {
-              ccvalid = true;
-              $('div.card_number_div .cards').removeClass('not_accepted');
-              $('input[name="card_number"]').removeClass('not-valid');
-              $('input[name="card_number"]').addClass('valid');
-              $('input[name="card_type"]').val(result.card_type.name.toUpperCase());
-              $('input[name="card_type"]').addClass('valid');
-              $('input[name="card_type"]').removeClass('not-valid');
-          } else {
-              ccvalid = false;
-              if($('input[name="card_number"]').val().length > 1){
-                  if(!result.card_accepted){
-                      $('div.card_number_div .cards').addClass('not_accepted');
-                  }else{
-                      $('div.card_number_div .cards').removeClass('not_accepted');
-                  }
-                  $('input[name="card_number"]').addClass('not-valid');
-                  $('input[name="card_type"]').addClass('not-valid');
-              }else{
-                  $('div.card_number_div .cards').removeClass('not_accepted');
-              }
-              $('input[name="card_number"]').removeClass('valid');
-              $('input[name="card_type"]').removeClass('valid');
-              if(!result.card_accepted && result.card_type != null){
-                  var badCard = $('#badcard').text().replace(/\s+/, "");
-                  $('input[name="card_type"]').val(badCard.replace('{card}',result.card_type.name.toUpperCase()));
-              }
-          }
-      });
+    if (!ccvalid) {
+      errString += $('#err_cardnumber').text().replace(/\s+/, "") + ', ';
+      // $('input[name="card_number"]').addClass('not-valid');
+      checks = false;
+    }
+    if (!cardholdervalid) {
+      errString += $('#err_cardholder').text().replace(/\s+/, "") + ', ';
+      checks = false;
+      $('input[name="card_holder"]').addClass('invalid');
+    }
+    if (!cardcvvvalid) {
+      errString += $('#err_cvv').text().replace(/\s+/, "") + ', ';
+      checks = false;
+      // $('input[name="card_cvv"]').addClass('not-valid');
+    }
+    if (!cardexpiryvaid) {
+      errString += $('#err_expiry').text().replace(/\s+/, "");
+      checks = false;
+      //     $('input[name="expMM"], input[name="expYY"]').addClass('not-valid');
+    }
+    if (!checks) {
+      $('#paybtn-cc').show();
+      $('#loading-cc').addClass('hidden');
 
-      $('input[name="card_holder"]').on('keydown blur', function(event) {
-          if (event.which == 13) {
-              event.preventDefault();
-          }
-          var val = $('input[name="card_holder"]').val();
-          var isValid = val.trim().split(' ').length;
-          if (isValid > 1) {
-              $('input[name="card_holder"]').addClass('valid');
-              $('input[name="card_holder"]').removeClass('invalid');
-              cardholdervalid = true;
-          } else {
-              $('input[name="card_holder"]').removeClass('valid');
-              $('input[name="card_holder"]').addClass('invalid');
-              cardholdervalid = false;
-          }
-      });
+      alert(errString.removeEnd(', '));
+      return false;
+    } else {
+      $('#paybtn-cc').hide();
+      $('#loading-cc').removeClass('hidden');
+    }
+    return true;
+  });
 
-      $('input[name="card_cvv"]').on('keydown blur', function(event) {
-          if (event.which == 13) {
-              event.preventDefault();
-          }
-          var val = $('input[name="card_cvv"]').val();
-          if (val.length > 1) {
-              $('input[name="card_cvv"]').addClass('valid');
-              $('input[name="card_cvv"]').removeClass('not-valid');
-              cardcvvvalid = true;
-          } else {
-              $('input[name="card_cvv"]').addClass('not-valid');
-              $('input[name="card_cvv"]').removeClass('valid');
-              cardcvvvalid = false;
-          }
-      });
+  $('input[name="card_number"]').validateCreditCard(function(result) {
+    if (result && result.card_type != null) {
+      var text = $('#badcard').text();
+      text = text.replace('{card}', result.card_type.name.toUpperCase());
+      $('.arrow_box').text(text);
+    }
+    if (result.length_valid && result.luhn_valid && result.card_accepted) {
+      ccvalid = true;
+      $('div.card_number_div .cards').removeClass('not_accepted');
+      $('input[name="card_number"]').removeClass('not-valid');
+      $('input[name="card_number"]').addClass('valid');
+      $('input[name="card_type"]').val(result.card_type.name.toUpperCase());
+      $('input[name="card_type"]').addClass('valid');
+      $('input[name="card_type"]').removeClass('not-valid');
+    } else {
+      ccvalid = false;
+      if ($('input[name="card_number"]').val().length > 1) {
+        if (!result.card_accepted) {
+          $('div.card_number_div .cards').addClass('not_accepted');
+        } else {
+          $('div.card_number_div .cards').removeClass('not_accepted');
+        }
+        $('input[name="card_number"]').addClass('not-valid');
+        $('input[name="card_type"]').addClass('not-valid');
+      } else {
+        $('div.card_number_div .cards').removeClass('not_accepted');
+      }
+      $('input[name="card_number"]').removeClass('valid');
+      $('input[name="card_type"]').removeClass('valid');
+      if (!result.card_accepted && result.card_type != null) {
+        var badCard = $('#badcard').text().replace(/\s+/, "");
+        $('input[name="card_type"]').val(badCard.replace('{card}', result.card_type.name.toUpperCase()));
+      }
+    }
+  });
 
-      $('input[name="expMM"], input[name="expYY"]').change(function(event) {
-          var val = $('input[name="expMM"]').val();
-          var val2 = $('input[name="expYY"]').val();
-          var expDate = new Date(Date.parse('20'+val2+'-'+val+'-01'));
-          var fuDate = new Date(expDate.setDate(expDate.getDate()+30)); //add 30 days
-          var now = new Date();
-          var notExpired = fuDate > now;
-          if ((val != '--' && val2 != '--') && notExpired == true) {
-              $('input[name="card_expiry"]').val(val + val2);
-              $('input[name="expMM"]').addClass('svalid');
-              $('input[name="expYY"]').addClass('svalid');
-              $('input[name="expMM"]').removeClass('not-valid');
-              $('input[name="expYY"]').removeClass('not-valid');
-              cardexpiryvaid = true;
-          } else {
-              $('input[name="expMM"]').addClass('not-valid');
-              $('input[name="expYY"]').addClass('not-valid');
-              $('input[name="expMM"]').removeClass('svalid');
-              $('input[name="expYY"]').removeClass('svalid');
-              cardexpiryvaid = false;
-          }
-      });
-  }).call(this);
+  $('input[name="card_holder"]').on('keydown blur', function(event) {
+    if (event.which == 13) {
+      event.preventDefault();
+    }
+    var val = $('input[name="card_holder"]').val();
+    var isValid = val.trim().split(' ').length;
+    if (isValid > 1) {
+      $('input[name="card_holder"]').addClass('valid');
+      $('input[name="card_holder"]').removeClass('invalid');
+      cardholdervalid = true;
+    } else {
+      $('input[name="card_holder"]').removeClass('valid');
+      $('input[name="card_holder"]').addClass('invalid');
+      cardholdervalid = false;
+    }
+  });
+
+  $('input[name="card_cvv"]').on('keydown blur', function(event) {
+    if (event.which == 13) {
+      event.preventDefault();
+    }
+    var val = $('input[name="card_cvv"]').val();
+    if (val.length >= 1) {
+      $('input[name="card_cvv"]').addClass('valid');
+      $('input[name="card_cvv"]').removeClass('not-valid');
+      cardcvvvalid = true;
+    } else {
+      if (!isEmpty(val.length)) {
+        $('input[name="card_cvv"]').addClass('not-valid');
+      }
+      $('input[name="card_cvv"]').removeClass('valid');
+      cardcvvvalid = false;
+    }
+  });
+
+  $('input[name="expMM"], input[name="expYY"]').change(function(event) {
+    var val = $('input[name="expMM"]').val();
+    var val2 = $('input[name="expYY"]').val();
+    var expDate = new Date(Date.parse('20' + val2 + '-' + val + '-01'));
+    var fuDate = new Date(expDate.setDate(expDate.getDate() + 30)); //add 30 days
+    var now = new Date();
+    var notExpired = fuDate > now;
+    if ((val != '--' && val2 != '--') && notExpired == true) {
+      $('input[name="card_expiry"]').val(val + val2);
+      $('input[name="expMM"]').addClass('svalid');
+      $('input[name="expYY"]').addClass('svalid');
+      $('input[name="expMM"]').removeClass('not-valid');
+      $('input[name="expYY"]').removeClass('not-valid');
+      cardexpiryvaid = true;
+    } else {
+      $('input[name="expMM"]').addClass('not-valid');
+      $('input[name="expYY"]').addClass('not-valid');
+      $('input[name="expMM"]').removeClass('svalid');
+      $('input[name="expYY"]').removeClass('svalid');
+      cardexpiryvaid = false;
+    }
+  });
+}).call(this);
 
 
-$(document).ready(function(){
+$(document).ready(function() {
 
-    var api_url = "https://pay.mondido.com/v1/";
-    var is_test = false;
-    
-    var Spinner = {};
-    try{
+  var api_url = mondidoSettings.config.system.endpoint;
+  var is_test = false;
+
+  var Spinner = {};
+  try {
     var spinner = new Spinner().spin();
     $('#mpspin').append(spinner.el);
-    $('.spinner').css({'position':'relative','top':'-29px'});
+    $('.spinner').css({
+      'position': 'relative',
+      'top': '-29px'
+    });
     spinner.stop();
 
-}catch(e){
-    
-}
-    var spin_it = function(start){
-        return;
-        if(start == true){
-            $("#checkoutButtonDiv img").hide();
-            spinner = new Spinner().spin();
-            $('#mpspin').append(spinner.el);
-            $('.spinner').css({'position':'relative','top':'-29px','z-index':'200'});
-        }else{
-            $("#checkoutButtonDiv img").show();
-            spinner.stop();
-        }
-    };
+  } catch (e) {
+
+  }
+
+  var spin_it = function(start) {
+    return;
+    if (start == true) {
+      $("#checkoutButtonDiv img").hide();
+      spinner = new Spinner().spin();
+      $('#mpspin').append(spinner.el);
+      $('.spinner').css({
+        'position': 'relative',
+        'top': '-29px',
+        'z-index': '200'
+      });
+    } else {
+      $("#checkoutButtonDiv img").show();
+      spinner.stop();
+    }
+  };
 
 
-    $("#checkoutButtonDiv").click(function(){
-       spin_it(true);
-       var request_token = api_url+"request_token?token="+Mondido.token+"&transaction_id="+Mondido.transaction.id+"&merchant_id="+Mondido.merchant.id+"&test="+is_test;
+  $("#checkoutButtonDiv").click(function() {
+    spin_it(true);
+    var request_token = api_url + "request_token?token=" + Mondido.token + "&transaction_id=" + Mondido.transaction.id + "&merchant_id=" + Mondido.merchant.id + "&test=" + is_test;
 
-       var jqxhr = $.get( request_token, function() {
-        }).done(function(data) {
-            do_log(data.masterpass);
-           handleConnectWithMasterPass(data.masterpass);
+    var jqxhr = $.get(request_token, function() {}).done(function(data) {
+      do_log(data.masterpass);
+      handleConnectWithMasterPass(data.masterpass);
 
 
-          }).fail(function() {
-            do_log("checkoutButtonDiv -> fail");
-            spin_it(false);
-          }).always(function() {
-            do_log("checkoutButtonDiv -> always");
-          }).done(function() {
-            spin_it(false);
-          });
-
+    }).fail(function() {
+      do_log("checkoutButtonDiv -> fail");
+      spin_it(false);
+    }).always(function() {
+      do_log("checkoutButtonDiv -> always");
+    }).done(function() {
+      spin_it(false);
     });
 
-    function handleConnectWithMasterPass(mp_obj) {
-      var connect_data;
+  });
 
-      connect_data =  {
-        "requestToken": mp_obj.request_roken,
-        "callbackUrl": mp_obj.callback_rrl,
-        "merchantCheckoutId": mp_obj.merchant_checkout_id,
-        "allowedCardTypes": mp_obj.allowed_card_types,
-        "requestedDataTypes": mp_obj.requested_data_types,
-        "version":"v6",
-        "loyaltyEnabled":  mp_obj.loyalty_enabled,
-        "requestBasicCheckout":  mp_obj.request_basic_checkout,
-        "suppressShippingAddressEnable":  mp_obj.suppress_shipping_address_enable,
-        "successCallback": handleCallbackSuccess,
-        "failureCallback": handleCallbackFailure,
-        "cancelCallback": handleCallbackCancel
-      };
-      do_log(connect_data);
+  function handleConnectWithMasterPass(mp_obj) {
+    var connect_data;
 
-      MasterPass.client.checkout(connect_data);
+    connect_data = {
+      "requestToken": mp_obj.request_roken,
+      "callbackUrl": mp_obj.callback_rrl,
+      "merchantCheckoutId": mp_obj.merchant_checkout_id,
+      "allowedCardTypes": mp_obj.allowed_card_types,
+      "requestedDataTypes": mp_obj.requested_data_types,
+      "version": "v6",
+      "loyaltyEnabled": mp_obj.loyalty_enabled,
+      "requestBasicCheckout": mp_obj.request_basic_checkout,
+      "suppressShippingAddressEnable": mp_obj.suppress_shipping_address_enable,
+      "successCallback": handleCallbackSuccess,
+      "failureCallback": handleCallbackFailure,
+      "cancelCallback": handleCallbackCancel
     };
+    do_log(connect_data);
 
-    function handleCallbackSuccess(data) {
-      var fullPath;
-      var callbackPath;
-      spin_it(true);
-      callbackPath = "?oauth_token="+data.oauth_token;
-      callbackPath += "&oauth_verifier="+data.oauth_verifier;
-      callbackPath += "&checkout_resource_url="+data.checkout_resource_url;
+    MasterPass.client.checkout(connect_data);
+  };
 
-      fullPath = window.location.origin + "/oauthcallback";
-      fullPath += callbackPath;
+  function handleCallbackSuccess(data) {
+    var fullPath;
+    var callbackPath;
+    spin_it(true);
+    callbackPath = "?oauth_token=" + data.oauth_token;
+    callbackPath += "&oauth_verifier=" + data.oauth_verifier;
+    callbackPath += "&checkout_resource_url=" + data.checkout_resource_url;
 
-      do_log("handleCallbackSuccess request-->");
-      do_log(fullPath);
+    fullPath = window.location.origin + "/oauthcallback";
+    fullPath += callbackPath;
 
-      $.get(fullPath, function(data, status){
-        window.location.replace(data);
-      });
-    }
+    do_log("handleCallbackSuccess request-->");
+    do_log(fullPath);
 
-    function handleCallbackFailure(data) {
-      do_log("handleCallbackFailure");
-      do_log(data);
-      spin_it(false);
-    }
+    $.get(fullPath, function(data, status) {
+      window.location.replace(data);
+    });
+  }
 
-    function handleCallbackCancel(data) {
-      do_log("handleCallbackCancel");
-      do_log(data);
-      spin_it(false);
-    }
+  function handleCallbackFailure(data) {
+    do_log("handleCallbackFailure");
+    do_log(data);
+    spin_it(false);
+  }
 
-    function getJsonFromUrl() {
-      var query = location.search.substr(1);
-      var result = {};
-      query.split("&").forEach(function(part) {
-        var item = part.split("=");
-        result[item[0]] = decodeURIComponent(item[1]);
-      });
-      return result;
-    }
+  function handleCallbackCancel(data) {
+    do_log("handleCallbackCancel");
+    do_log(data);
+    spin_it(false);
+  }
 
-    var locationParams = getJsonFromUrl();
+  function getJsonFromUrl() {
+    var query = location.search.substr(1);
+    var result = {};
+    query.split("&").forEach(function(part) {
+      var item = part.split("=");
+      result[item[0]] = decodeURIComponent(item[1]);
+    });
+    return result;
+  }
 
-    if (locationParams.checkout) {
+  var locationParams = getJsonFromUrl();
+
+  if (locationParams.checkout) {
     callbackPath += "?connected=true"
     checkout = true;
     $("#pairingConfigDiv").css("display", "block");
     $("#merchantInit").css("display", "none");
-    }
+  }
 
-    $("#pairingConfigDiv").css("display", "block");
-    $("#merchantInit").css("display", "none");
+  $("#pairingConfigDiv").css("display", "block");
+  $("#merchantInit").css("display", "none");
 });
 
 // Layout settings
-(function($) {  
-  $("img.lazy").lazyload();
+(function($) {
 
-  if (mondidoSettings.layout.show_logo == true){
+  if (mondidoSettings.layout.show_logo == true) {
     $(".m-layout-logo").attr("src", mondidoSettings.layout.logo_url);
     $(".m-layout-show-logo").removeClass("hidden");
+  }
+
+  $('.m-ent-tab').bind("keypress", function(e) {
+    if (e.keyCode == 13) {
+      var inps = $("input, select"); //add select too
+      for (var x = 0; x < inps.length; x++) {
+        if (inps[x] == this) {
+          while ((inps[x]).name == (inps[x + 1]).name) {
+            x++;
+          }
+          if ((x + 1) < inps.length) $(inps[x + 1]).focus();
+        }
+      }
+      e.preventDefault();
+    }
+  });
+
+  if (mondidoSettings.convertCurrency.amount != '') {
+    var el = $('#currencyConvert');
+    el.html('Will be charged as ' + mondidoSettings.convertCurrency.amount + ' ' + mondidoSettings.convertCurrency.currency);
+    var tab = mondidoSettings.convertCurrency.methods.replace(/([^a-z0-9]+)/gi, '-')
+
+    el.removeClass("hidden");
+
+    $('#' + tab + "_tab").prepend(el);
   }
 
 })(jQuery);
 
 
-
 (function($) {
-    $.QueryString = (function(a) {
-        if (a == "") return {};
-        var b = {};
-        for (var i = 0; i < a.length; ++i)
-        {
-            var p=a[i].split('=');
-            if (p.length != 2) continue;
-            b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
-        }
-        return b;
-    })(window.location.search.substr(1).split('&'))
+  $.QueryString = (function(a) {
+    if (a == "") return {};
+    var b = {};
+    for (var i = 0; i < a.length; ++i) {
+      var p = a[i].split('=');
+      if (p.length != 2) continue;
+      b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
+    }
+    return b;
+  })(window.location.search.substr(1).split('&'))
 })(jQuery);

--- a/html/pay-out.html
+++ b/html/pay-out.html
@@ -1,530 +1,635 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <!-- Mondido PayOut v1.4.2, (c) Mondido Payments AB 2016, hello@mondido.com -->
-        <script>
-            var mondidoSettings = {
-                /// Company layout settings
-                layout: {
-                    name: "Mondido",
-                    show_logo: true,
-                    logo_url: "https://cdn-02.mondido.com/www/img/mondido-payments-black-2016-2.png",
-                    terms_and_conditions_url: "https://www.mondido.com/terms",
-                },
+<head>
+  <meta charset="UTF-8">
+  <!-- Mondido PayOut v2.0, (c) Mondido Payments AB 2016, hello@mondido.com -->
+  <script>
+    var mondidoSettings = {
 
-                /// Cards/Payment layout settings
-                activePaymentMethod: 'credit_card_tab',
+      /// Company layout settings
+      layout: {
+        name: "{{ transaction.merchant.settings_hosted['v2']['layout']['name'] | default_string_empty_name  }}  ",
+        show_logo: {{ transaction.merchant.settings_hosted['v2']['layout']['show_logo'] | default_true }},
+        logo_url: "{{ transaction.merchant.settings_hosted['v2']['layout']['logo_url'] | default_string_empty_logo  }}",
+        terms_and_conditions_url: "{{ transaction.merchant.settings_hosted['v2']['terms_and_conditions']['fallback'] | default_string_empty_terms }}"
+      },
 
-                supportedCards: {
-                    amex: {active: true, currencies: ['sek']},
-                    diners: {active: false},
-                    jcb: {active: false},
-                    laser: {active: false},
-                    electron: {active: true, currencies: ['all']},
-                    visa: {active: true, currencies: ['all']},
-                    mastercard: {active: true, currencies: ['all']},
-                    maestro: {active: true, currencies: ['all']},
-                    discover: {active: false}
-                },
-                supportedPaymentMethods: [
-                    {name: 'swish_tab', active: false, currencies:['all'], countries:['all']},
-                    {name: 'credit_card_tab', active: true, currencies:['all'], countries:['all']},
-                    {name: 'paypal_tab', active: false, currencies:['all'], countries:['all']},
-                    {name: 'trustly_tab', active: false, currencies:['all'], countries:['all','se','at','be','bg','hr','cz','cy','dk','ee','fi','fr','de','gr','hu','ie','it','lv','lt','lu','mt','nl','no','pl','pt','ro','sk','si','es','gb']},
-                    {name: 'invoice_tab', active: false, currencies:['all'], countries:['all','se'],
-                        segmentation: {
-                            b2c: true,
-                            b2b: false,
-                            defualt: "b2c"
-                        },
-                        AgreementCode: "code"
-                    },
-                    {name: 'masterpass_tab', active: false, currencies:['all'], countries:['all']},
-                ],
+      /// Cards/Payment layout settings
+      activePaymentMethod: "{{ transaction.merchant.settings_hosted['v2']['active_payment_method'] | default_payment_method  }}",
 
-                /// Config settings
-                metadata: '{{ transaction.metadata | replace: "\'", "" }}',
-                currency: '{{ transaction.currency }}',
-                country_code: '{{ transaction.payment_details.country_code }}',
+      supportedCards: {
+        amex: {active: true, currencies: ['sek']},
+        diners: {active: false},
+        jcb: {active: false},
+        laser: {active: false},
+        electron: {active: true, currencies: ['all']},
+        visa: {active: true, currencies: ['all']},
+        mastercard: {active: true, currencies: ['all']},
+        maestro: {active: true, currencies: ['all']},
+        discover: {active: false}
+      },
 
-                config: {
-                    development: false,
-                    system: {
-                        endpoint: "https://pay.mondido.com/v1/",
-                        log: false,
-                        payment_js_endpoint: "https://cdn-02.mondido.com/www/js/mondido.payment.1.14.2.1.js",
-                        lang_endpoint: "https://cdn-02.mondido.com/www/js/lang.1.6.5.js",
-                        bootstrap_endpoint: "https://cdn-02.mondido.com/www/js/bootstrap.min.js?v=3.0",
-                        jquery_endpoint: "https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js",
-                        fontawesome: "https://use.fontawesome.com/c66b4c0ee0.js"
-                    }
-                }
-            }
+      supportedPaymentMethods: [
+        {name: 'credit_card_tab', active: {{ transaction.merchant.settings_hosted['v2']['credit_card']['active'] | default_true }}, currencies:['all'], countries:['all']},
+        {name: 'swish_tab', active: {{ transaction.merchant.settings_hosted['v2']['swish']['active'] | default_false }}, currencies:['all'], countries:['se']},
+        {name: 'paypal_tab', active: {{ transaction.merchant.settings_hosted['v2']['paypal']['active'] | default_false }}, currencies:['all'], countries:['all']},
+        {name: 'trustly_tab', active: {{ transaction.merchant.settings_hosted['v2']['trustly']['active'] | default_false }}, currencies:['all'], countries:['all','se','at','be','bg','hr','cz','cy','dk','ee','fi','fr','de','gr','hu','ie','it','lv','lt','lu','mt','nl','no','pl','pt','ro','sk','si','es','gb']},
+        {name: 'invoice_tab', active: {{ transaction.merchant.settings_hosted['v2']['invoice']['active'] | default_false }}, currencies:['all'], countries:['all'],
+          segmentation: {
+            b2c: {{ transaction.merchant.settings_hosted['v2']['invoice']['segmentation']['b2c'] | default_true }},
+            b2b: {{ transaction.merchant.settings_hosted['v2']['invoice']['segmentation']['b2b'] | default_false }},
+            defualt: "{{ transaction.merchant.settings_hosted['v2']['invoice']['segmentation']['defualt'] | default_segmentation  }}"
+          },
+          AgreementCode: "{{ transaction.merchant.settings_hosted['v2']['invoice']['agreement_code'] }}"
+        },
+        {name: 'masterpass_tab', active: {{ transaction.merchant.settings_hosted['v2']['masterpass']['active'] | default_false }}, currencies:['all'], countries:['all']},
+      ],
 
-            if(document.Mondido != undefined && document.Mondido.systemInfo){
-                //problems:[{type: 'swish', message: 'Swish is out of order'},{type: 'credit_card', issuer: 'nordea', message: 'Nordea kräver 3D Secure'}]
-                mondidoSettings.systemInfo = document.Mondido.systemInfo;
-            }
-        </script>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <meta name="robots" content="noindex, nofollow"/>
+      /// Config settings
+      metadata: '{{ transaction.metadata | replace_metadata }}',
+      currency: '{{ transaction.currency }}',
+      country_code: '{{ transaction.payment_details.country_code | default_metadata_country }}',
+      metadataCountry: "{{ transaction.metadata['order']['customer']['default_address']['country'] }}",
 
-        <link href="https://cdn-02.mondido.com/www/css/multi.1.7.3.css" rel="stylesheet" />
-        <title>Payment</title>
-    </head>
+      customer: {
+        name: "{{ transaction.metadata['customer_firstname'] }} {{ transaction.metadata['customer_last'] }}",
+        phone: "{{ transaction.metadata['order']['billing_address']['phone'] }}",
+        email: "{{ transaction.metadata['email'] }}",
 
-    <body>
-        <div id="main_area">
-            <div id="payform" class="container grayc">
-                <div class="m-layout-show-logo col-xs-12 text-center hidden">
-                    <img class="m-layout-logo"/>
-                </div>
-                <div data-mulang="choose_payment_option" class="row text-center choose mulang">
-                    Please choose payment option
-                </div>
+        billing: {
+          first_name: "{{ transaction.metadata['order']['billing_address']['first_name'] }}",
+          last_name: "{{ transaction.metadata['order']['billing_address']['last_name'] }}",
+          address1: "{{ transaction.metadata['order']['billing_address']['address1'] }}",
+          phone: "{{ transaction.metadata['order']['billing_address']['phone'] }}",
+          city: "{{ transaction.metadata['order']['billing_address']['city'] }}",
+          zip: "{{ transaction.metadata['order']['billing_address']['zip'] }}",
+          address2: "{{ transaction.metadata['order']['billing_address']['address2'] }}",
+          company: "{{ transaction.metadata['order']['billing_address']['company'] }}"
+        }
+      },
 
-                <!-- ######### Nav tabs ######### -->
-                <div role="tabpanel">
-                    <ul id="myTab" class="nav nav-tabs" role="tablist" >
-                        <li role="presentation" class="credit_card_tab" style="display:none;">
-                            <a href="#credit_card_tab" aria-controls="credit_card_tab" role="tab" data-toggle="tab" class="card-tab">
-                                <img class="lazy" data-original="https://cdn-02.mondido.com/www/img/cards/mc-visa_payment_logo.png" alt="Visa/MasterCard">
-                                <br>
-                                <small data-mulang="card_payment" class="mulang">
-                                    Card
-                                </small>
-                                <div class="mrk">
-                                </div>
-                            </a>
-                        </li>
-                        <li role="presentation" class="swish_tab" style="display:none;">
-                            <a href="#swish_tab" aria-controls="swish_tab" role="tab" data-toggle="tab">
-                            <img class="lazy" data-original="https://cdn-02.mondido.com/www/img/swish-logo.png" alt="Swish">
-                                <br>
-                                <small data-mulang="swish_payment" class="mulang">Swish</small>
-                                <div class="mrk"></div>
-                            </a>
-                        </li>
-                        <li role="presentation" class="trustly_tab" style="display:none;">
-                            <a href="#trustly_tab" aria-controls="trustly_tab" role="tab" data-toggle="tab">
-                                <img class="lazy" data-original="https://cdn-02.mondido.com/www/img/Trustly.png" alt="Trustly">
-                                <br>
-                                <small data-mulang="bank_payment" class="mulang">
-                                    Bank
-                                </small>
-                                <div class="mrk">
-                                </div>
-                            </a>
-                        </li>
-                        <li role="presentation" class="paypal_tab" style="display:none;">
-                            <a href="#paypal_tab" aria-controls="paypal_tab" role="tab" data-toggle="tab">
-                                <img class="lazy" data-original="https://cdn-02.mondido.com/www/img/paypal-1.png" alt="PayPal">
-                                <br>
-                                <small data-mulang="paypal_payment" class="mulang">
-                                    PayPal
-                                </small>
-                                <div class="mrk">
-                                </div>
-                            </a>
-                        </li>
-                        <li role="presentation" class="invoice_tab" style="display:none;">
-                            <a href="#invoice_tab" aria-controls="invoice_tab" role="tab" data-toggle="tab" class="card-tab" >
-                                <i class="fa fa-file-text-o"></i>
+      convertCurrency: {
+        amount: "{{ transaction.convert_currency['amount'] }}",
+        currency: "{{ transaction.convert_currency['currency'] }}",
+        methods: "{{ transaction.convert_currency['payment_methods'] }}"
+      },
 
-                                <small data-mulang="invoice_payment" class="mulang">
-                                    Invoice
-                                </small>
-                                <div class="mrk">
-                                </div>
-                            </a>
-                        </li>
-                        <li role="presentation" class="masterpass_tab" style="display:none;top:-12px;">
-                            <a href="#masterpass_tab" aria-controls="masterpass_tab" role="tab" data-toggle="tab" class="card-tab">
-                                <img class="lazy" data-original="https://cdn-02.mondido.com/www/img/masterpass1.png" alt="Masterpass" />
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <!-- ######### Tab panes ######### -->
-                <div id="myTabsegmentation_toggleContent" class="row tab-content">
-                    <div class="row header">
-                        <div class="col-xs-12 text-center">
-                            <p class="amount mulang" data-mulang="amount['{{ transaction.amount | round }}','{{ currency }}']">
-                                {{ transaction.amount | round }} {{ currency }}
-                            </p>
-                            <div id="errors" class="alert alert-danger">
-                            </div>
-                        </div>
-                    </div>
-                    <!-- invoice -->
-                    <div role="tabpanel" class="tab-pane fade" id="invoice_tab" aria-labelledBy="invoice_tab">
-                        <!--
-                            ######### Invoice #########
-                            s******** START   *********
-                        -->
-                        <form id="invoiceform" class="form-signin go-bottom" method="post" role="form">
-                            <input type="hidden" id="payment_method" name="payment_method"/>
-                            <input type="hidden" id="country_code" name="country_code" value="{{ transaction.payment_details.country_code }}"/>
-                            <input type="hidden" id="pending_payment_customer" name="pending_payment_customer"/>
-                            <input type="hidden" id="segmentation" name="segmentation" value="{{{ transaction.payment_details.segmentation }}" />
+      config: {
+        system: {
+          endpoint: "{{ transaction.merchant.settings_hosted['v2']['system']['endpoint']['pay'] | default_endpoint  }}",
+          log: false,
+          payment_js_endpoint: "{{ transaction.merchant.settings_hosted['v2']['system']['endpoint']['payment_js'] | default_payment_js_endpoint  }}",
+          lang_endpoint: "{{ transaction.merchant.settings_hosted['v2']['system']['endpoint']['lang'] | default_lang_endpoint  }}",
+          fontawesome: "https://use.fontawesome.com/c66b4c0ee0.js",
+          css_endpoint: "{{ transaction.merchant.settings_hosted['v2']['system']['endpoint']['css'] | default_css_endpoint  }}"
+        }
+      }
+    }
 
-                            <div class="row hidden" id="segmentation_toggle">
-                                <div class="row pull-right">
-                                    <button type="button" id="b2c" data-value="b2c" class="segmentation_select btn btn-sm"><span class="mulang" data-mulang="individual">Individual</span></button>
-                                    <button type="button" id="b2b" data-value="b2b" class="segmentation_select btn btn-sm"><span class="mulang" data-mulang="business">Business</span></button>
-                                </div>
-                                <br />
-                            </div>
-                  
-                            <div class="row spacer" id="row-email">
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <input type="text" coolname="E-post" class="form-control next-email mulang" min="3" max="255" id="email" name="email" placeholder="Your email address" tabindex="1" value="{{ transaction.payment_details.email }}" autocomplete="email" autofocus="true" />
-                                         <label for="email" data-mulang="your_email_address" class="mulang">Your email address</label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row hidden spacer" id="row-phone-details">
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <input data-numeric type="tel" class="form-control next-phone mulang" id="phone" name="phone" placeholder="Your phone number" value="{{ transaction.payment_details.phone }}" maxlength="20" tabindex="2" coolname="Telefonnummer"  autocomplete="cc-number" />
-                                         <label for="phone" data-mulang="your_phone_number" class="mulang">Your phone number</label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row hidden spacer" id="row-ssn-details">
-                                <div class="row">
-                                    <div class="col-xs-12">
-                                        <input data-numeric type="tel" class="form-control next-ssn mulang" id="ssn" name="ssn" placeholder="ååååmmdd ••••" value="{{ transaction.payment_details.ssn }}" maxlength="13" tabindex="3" coolname="Personnummer"  autocomplete="cc-number" />
-                                         <label for="ssn" data-mulang="your_social_security_number" class="mulang">Your Social Security number</label>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row hidden" id="row-ssn-details-loading">
-                                <div class="row">
-                                    <div class="col-xs-12" id="loading" data-mulang="loading" class="mulang">
-                                        Loading
-                                        <div class="spinner">
-                                          <div class="rect1"></div>
-                                          <div class="rect2"></div>
-                                          <div class="rect3"></div>
-                                          <div class="rect4"></div>
-                                          <div class="rect5"></div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row hidden" id="row-ssn-details-error">
-                                <div class="row">
-                                    <div class="col-xs-12 error" data-mulang="invlice_address_could_not_be_retrieved" class="mulang">
-                                        Your address could not be retrieved . Check that you have entered the correct Social Security number. Example 198605141234
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="row hidden" id="row-customer-details">
-                                <div class="row" style="margin: 5px;">
-                                    <div class="col-xs-6">
-                                        <input type="text" data-mulang="first_name:placeholder"  coolname="Förnamn" class="form-control mulang" min="1" max="12" id="first_name" name="first_name" placeholder="First name" tabindex="4" value="{{ transaction.payment_details.mask_first_name }}" disabled/>
-                                        <label for="first_name" data-mulang="first_name" class="mulang">First name</label>
-                                    </div>
-                                    <div class="col-xs-6">
-                                        <input type="text" data-mulang="last_name:placeholder" coolname="Efternamn" class="form-control mulang" min="1" max="12" id="last_name" name="last_name" placeholder="Last name" tabindex="4" value="{{ transaction.payment_details.mask_last_name }}" disabled/>
-                                        <label for="last_name" data-mulang="last_name" class="mulang">Last name</label>
-                                    </div>
-                                </div>
-                                <div class="row" style="margin: 5px;">
-                                    <div class="col-xs-12">
-                                        <div class="address">
-                                            <input data-text data-mulang="address:placeholder"  type="text" class="form-control mulang" id="address_1" name="address_1" value="{{ transaction.payment_details.mask_address_1 }}" maxlength="255" placeholder="Address" tabindex="5" coolname="Adress 1" disabled/>
-                                            <label for="address_1" data-mulang="address" class="mulang">Address</label>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="row" style="margin: 5px;">
-                                    <div class="col-xs-12">
-                                        <div class="address">
-                                            <input data-text data-mulang="co_address:placeholder"  type="text" class="form-control mulang" id="address_2" name="address_2" value="{{ transaction.payment_details.mask_address_2 }}" maxlength="255" placeholder="C/O Adress" tabindex="6" coolname="C/O adress" disabled/>
-                                            <label for="address_2" data-mulang="co_address" class="mulang">C/O Adress</label>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-xs-6">
-                                        <input type="text" data-mulang="zip:placeholder"  coolname="Postnummer" class="form-control mulang" min="5" max="12" id="zip" name="zip" placeholder="zip" tabindex="7" value="{{ transaction.payment_details.mask_zip }}" disabled/>
-                                        <label for="zip" data-mulang="zip" class="mulang">Zip code</label>
-                                    </div>
-                                    <div class="col-xs-6">
-                                        <input type="text" data-mulang="city:placeholder" coolname="Stad" class="form-control mulang" min="1" max="255" id="city" name="city" placeholder="City" tabindex="8" value="{{ transaction.payment_details.mask_city }}" disabled/>
-                                        <label for="city" data-mulang="city" class="mulang">City</label>
+    if(document.Mondido != undefined && document.Mondido.systemInfo){
+      //problems:[{type: 'swish', message: 'Swish is out of order'},{type: 'credit_card', issuer: 'nordea', message: 'Nordea kräver 3D Secure'}]
+      mondidoSettings.systemInfo = document.Mondido.systemInfo;
+    }
+  </script>
+  <script type="text/javascript">
+    if (document.location.host) { mondidoSettings.config.development = false;  } else { mondidoSettings.config.development = true; }
 
-                                    </div>
-                                </div>
+    function load_css(css_url) {
+      document.write('<link href="'+css_url+'" rel="stylesheet" type="text/css" />');
+    }
+    if (mondidoSettings.config.development == true){
+     // load_css("css/multi.css");
+    } else {
+      load_css(mondidoSettings.config.system.css_endpoint);
+    }
+  </script>
 
-                                <div class="row">
-                                  <br>
-                                         <div class="col-xs-2">
-                                            <label class="bigcheck">
-                                                <input type="checkbox" class="bigcheck mulang" name="cheese" value="yes"  data-mulang="i_accept:placeholder" tabindex="9"  />
-                                                <span class="bigcheck-target"></span>
-                                            </label>
-                                      </div>                 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="robots" content="noindex, nofollow"/>
+  <title>{{ transaction.merchant.settings_hosted['v2']['layout']['name'] | default_string_empty_name  }} payment window</title>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" type="text/javascript"></script>
+</head>
+<body>
+  {% assign show_logo = transaction.merchant.settings_hosted['v2']['layout']['show_logo'] | default_true %}
+  {% assign show_credit_card = transaction.merchant.settings_hosted['v2']['credit_card']['active'] | default_true %}
+  {% assign show_swish = transaction.merchant.settings_hosted['v2']['swish']['active'] | default_false %}
+  {% assign show_trustly = transaction.merchant.settings_hosted['v2']['trustly']['active'] | default_false %}
+  {% assign show_paypal = transaction.merchant.settings_hosted['v2']['paypal']['active'] | default_false %}
+  {% assign show_invoice = transaction.merchant.settings_hosted['v2']['invoice']['active'] | default_false %}
+  {% assign show_masterpass = transaction.merchant.settings_hosted['v2']['masterpass']['active'] | default_false %}
 
-                                        <div class="col-xs-10">
-                                        <span  id="accept_collector"class="mulang accept_collector" data-mulang="invoice_accept_conditions['']" style="font-size: 12px;">
-                                        Yes, I have read and accept Collector Bank\'s 
-                                        <a target="_new" href="https://www.collector.se/upload/Partners/Agreements/<AgreementCode>/Credit_terms_All_SE.pdf"> 
-                                        General Conditions For Invoice And Credit Accounts </a>
-                                        and
-                                        <a target="_new" href="http://www.collector.se/upload/Partners/Agreements/<AgreementCode>/SECCI_SE.pdf"> Standardised European Consumer Credit Information </a> , 
-                                        and <a target="_new" href="<url>"> 
-                                        Conditions #COPAMNY# </a>
-                                        </span>
-                                    </div>
-                                    </div>
-                                <div class="row">
-                                    <input data-mulang="pay_button:value" id="paybtn" class="btn btn-lg btn-success btn-block mulang" type="submit" value="Pay" tabindex="9"/>
-                                </div>
-                            </div>
+  {% assign show_powered_by = transaction.merchant.settings_hosted['v2']['layout']['show']['powered_by'] | default_true %}
 
-                            <div class="row footer comodotext" id="invoice_foot">
-                                <div class="text-center">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="250" height="18" viewBox="0 0 194 20">
-<path d="M24.74 4.05c-4.71 0-8.19 3.74-8.19 7.85 0 3.81 3.1 8.07 8.19 8.07 5.13 0 8.19-4.33 8.19-8 0-4.32-3.58-7.92-8.19-7.92m0 13.31c-3.17 0-5.33-2.64-5.33-5.39 0-2.71 2.13-5.35 5.33-5.35s5.33 2.64 5.33 5.32c0 2.88-2.27 5.42-5.33 5.42M35.72 0h2.86v19.59h-2.86zM42.74 0h2.86v19.59h-2.86zM98.61 4.05c-4.71 0-8.19 3.74-8.19 7.85 0 3.81 3.1 8.07 8.19 8.07 5.13 0 8.19-4.33 8.19-8 0-4.32-3.61-7.92-8.19-7.92m0 13.31c-3.16 0-5.33-2.64-5.33-5.39 0-2.71 2.13-5.35 5.33-5.35s5.34 2.64 5.34 5.32c0 2.88-2.27 5.42-5.34 5.42M112.24 5.83h-.07V4.46h-2.65v15.09h2.86v-8.26c0-2.16.75-3.3 1.65-3.78.69-.34 1.62-.55 2.06-.55V4.05c-.72.03-2.65.1-3.85 1.78M8.15 6.66c1.93 0 3.48.96 4.41 2.33l2.17-1.72c-1.48-1.92-3.82-3.19-6.54-3.19C3.48 4.08 0 7.82 0 11.94 0 15.75 3.1 20 8.19 20c2.89 0 5.13-1.37 6.5-3.22l-2.13-1.72c-.93 1.37-2.51 2.33-4.37 2.33-3.17 0-5.33-2.64-5.33-5.38-.04-2.71 2.09-5.35 5.29-5.35M73.7 6.66c1.93 0 3.48.96 4.41 2.33l2.16-1.72a8.178 8.178 0 0 0-6.53-3.19c-4.72 0-8.19 3.74-8.19 7.86 0 3.81 3.09 8.06 8.19 8.06 2.89 0 5.12-1.37 6.5-3.22l-2.13-1.72a5.285 5.285 0 0 1-4.37 2.33c-3.17 0-5.34-2.64-5.34-5.38-.03-2.71 2.1-5.35 5.3-5.35M56.12 4.05c-4.27 0-7.78 3.39-7.78 7.92 0 4.29 3.41 7.96 7.71 7.96 2.24 0 5.44-1.1 7.02-4.49h-2.99c-.79 1.06-2.14 1.92-3.93 1.92-1.92 0-4.26-1.2-4.98-4.12h12.55c.04-.2.07-.96.07-1.44.04-4.42-3.58-7.75-7.67-7.75m-4.92 7c.14-2.2 2.17-4.43 4.89-4.43 2.75 0 4.74 2.2 4.88 4.43H51.2zM87.22 0H84.4v4.49h-2.51V7.1h2.51v12.45h2.82V7.07h2.52V4.46h-2.52z" fill="#282828" />
-<path d="M154.91 6.66c-3.47 0-5.19 3.01-5.19 5.38 0 2.71 2.16 5.32 5.16 5.32 2.99 0 5.26-2.44 5.26-5.32.04-3.19-2.3-5.38-5.23-5.38m5.2 12.89v-2.33h-.04c-1.1 1.85-3.09 2.71-5.12 2.71-5.1 0-8.02-3.88-8.02-7.85 0-3.68 2.61-8 8.02-8 2.1 0 4.06.86 5.12 2.54h.04V4.49h2.85v15.1h-2.85zM137.16 6.66c-2.93 0-5.23 2.19-5.23 5.38 0 2.88 2.3 5.32 5.26 5.32 3 0 5.16-2.57 5.16-5.32-.03-2.37-1.72-5.38-5.19-5.38m-7.88 12.89V.51h2.85v5.8h.07c1.1-1.37 3.03-2.26 5.13-2.26 5.37 0 7.88 4.32 7.88 7.99 0 3.98-2.86 7.86-7.88 7.86-2.2 0-4.13-.86-5.37-2.54h-.03v2.16h-2.65zM172.63 4.05c-.62 0-2.89 0-4.44 2.02h-.07V4.46h-2.64v15.09h2.85v-8.23c0-3.02 1.62-4.7 3.99-4.7 3.79 0 3.79 3.53 3.79 4.7v8.2h2.85v-8.95c-.03-1.68-.34-2.89-.96-3.88-1.1-1.61-3.03-2.64-5.37-2.64M181.48 0h2.92v10.39l5.92-5.93h3.51l-6.75 6.62 6.92 8.44h-3.34l-6.26-7.75v7.75h-2.92z" fill="#282828" fill-opacity=".5" />
-</svg>
-                                </div>
-                                <span class="mulang" data-mulang="invoice_footer_conditions" >
-                                    When you select the invoice you will receive your goods before you pay. You can then choose to pay the whole amount at once or split the payment into smaller parts . In order to deal with the bill collectors will be at least 18 years. The invoice will be sent by e-mail. More information can be found at
-                                </span>     <a target="_new" href="https://www.collector.se">https://www.collector.se</a>
-                            </div>
-                        </form>
-                        <!--
-                        ********* END   *********
-                        ######### Invoice #########
-                        -->
-                    </div>
-                    <!-- /invoice -->
-                    <!-- card -->
-                    <div role="tabpanel" class="tab-pane fade" id="credit_card_tab" aria-labelledBy="credit_card_tab">
-                        <!--
-                            ######### CARD #########
-                            ********* START   *********
-                        -->
-                        <div class="row">
-                        <form id="mondidopayform" class="form-signin" method="post" role="form" autocomplete="off" aria-autocomplete="none">
-                            <input type="hidden" name="card_expiry" id="card_expiry" value="" />
-                            <div class="card_number_div">
-                                <label id="label_card_holder" data-mulang="card_holder" class="mulang">
-                                    Card holder name:
-                                </label>
-                                <input id="input_card_holder" data-mulang="card_holder_placeholder:placeholder" placeholder="Firstname Lastname"  type="text" class="form-control mulang" name="card_holder" value="{{ transaction.metadata['customer']['firstname'] }} {{ transaction.metadata['customer']['lastname'] }}" tabindex="1"  />
-                            </div>
-                            <label data-mulang="card_number" class="mulang">
-                                Card number:
-                            </label>
-                            <div class="card_number_div">
-                                <span class="cc-brand">
-                                </span>
-                                <input data-mulang="card_number_placeholder:placeholder" data-numeric type="tel" autocomplete="cc-number" class="mulang form-control cc-number" id="card_number" name="card_number" placeholder="•••• •••• •••• ••••" value="" maxlength="19" tabindex="2" coolname="cardnumber" autofocus="true" />
-                                <div class="cards">
-                                    <div data-mulang="card_not_accepted" class="arrow_box mulang">Card is currently not supported</div>
-                                </div>
-                            </div>
-                            <label hidden>
-                                Card Type
-                            </label>
-                            <input readonly="true" coolname="Korttyp" type="hidden" class="form-control" name="card_type" id="card_type"/>
-                            <div class="row">
-                                <div class="col-xs-4 nopadleft">
-                                    <label data-mulang="exp_month" class="mulang">
-                                        Month:
-                                    </label>
-                                    <input type="tel" coolname="month" class="form-control cc-exp cc-number" maxlength="2" min="1" max="12" id="expMM" name="expMM" placeholder="01" tabindex="3" required pattern="\d*" />
-                                </div>
-                                <div class="col-xs-4">
-                                    <label data-mulang="exp_year" class="mulang">
-                                        Year:
-                                    </label>
-                                    <input type="tel" coolname="year" class="form-control cc-exp cc-number" maxlength="2" min="16" max="36" id="expYY" name="expYY" placeholder="16" tabindex="4" required pattern="\d*" />
-                                </div>
-                                <div class="col-xs-4 nopadright">
-                                    <label data-mulang="cvc" class="mulang">
-                                        CVV:
-                                    </label>
-                                    <input type="tel" class="form-control cc-cvc cc-number" maxlength="4" min="0" max="9999" id="card_cvv" name="card_cvv" coolname="CVV" placeholder="•••" tabindex="5" required pattern="\d*" autocomplete="off" />
-                                </div>
-                            </div>
-                            <input data-mulang="pay_button:value" id="paybtn-cc" class="mulang btn btn-lg btn-success btn-block" type="submit" value="Pay" tabindex="6"/>
-                            <div id="loading-cc" class="hidden">
-                                <span class="mulang" data-mulang="loading">Loading:</span>
-                                <div class="spinner">
-                                  <div class="rect1"></div>
-                                  <div class="rect2"></div>
-                                  <div class="rect3"></div>
-                                  <div class="rect4"></div>
-                                  <div class="rect5"></div>
-                                </div>
-                            </div>
-                            <div class="footer">
-                                <div>
-                                    <div class="col-md-6">
-                                        <img class="card-img" src="https://cdn-02.mondido.com/www/img/visa-mastercard-amex.png" alt="cards"/>
-                                    </div>
-                                    <div class="col-md-6">
-                                        <img class="card-img" src="https://cdn-02.mondido.com/www/img/3dsecure.png" alt="3d secure"/>
-                                    </div>
-                                    <div class="comodotext mulang" data-mulang="safe_text">
-Your payment is made safe by Mondido. The store will never be in contact with your credit card information, all the information is sent encrypted to your bank. Mondido is PCI DSS Level 1 certified and use HTTPS / TLS, which is the banking industry standard for secure e-commerce transactions.
-                                    </div>
-                                </div>
-                            </div>
-                            <p class="clearfix">
-                            </p>
-                        </form>
-                        </div>
-                        <!--
-                            ######### CARD #########
-                            ********* STOP   *********
-                        -->
-                    </div>
-                    <!-- /card -->
-                    <!-- trustly -->
-                    <div role="tabpanel" class="tab-pane fade" id="trustly_tab" aria-labelledBy="trustly_tab" style="text-align: center;">
-                        <!--
-                            ######### Trustly #########
-                        -->
-                        <form action="" id="trustlyform" method="post" role="form" target="trustly">
-                            <input type="hidden" name="trustly" value="1" />
-                            <input type="hidden" name="trustly_locale" value="sv_SE" />
-                            <input type="hidden" name="trustly_country" value="SE" />
-                        </form>
+  {% assign show_card_visa = transaction.merchant.settings_hosted['v2']['supported_cards']['visa']['active'] | default_true %}
+  {% assign show_card_mastercard = transaction.merchant.settings_hosted['v2']['supported_cards']['mastercard']['active'] | default_true %}
+  {% assign show_card_amex = transaction.merchant.settings_hosted['v2']['supported_cards']['amex']['active'] | default_false %}
 
-                        <base target="_top">
-                            <iframe src="" name="trustly" width="95%" height="400" style="border: 0"></iframe>
-                            <div class="mulang" data-mulang="what_is_trustly">What is Trustly?</div>
-                        </base>
-                        <!--
-                        ######### Trustly #########
-                        -->
-                    </div>
-                    <!-- /trustly -->
-                    <!-- swish -->
-                    <div role="tabpanel" class="tab-pane fade" id="swish_tab" aria-labelledBy="swish_tab" style="text-align: center;">
-                        <form action="" class="form-signin go-bottom" id="swishform" method="post" role="form">
-                            <input type="hidden" name="swish" value="1" />
-                            <div class="row">
-                                <div class="mulang" data-mulang="easily_pay_with_swish_mobile">Pay with Swish Mobile</div>
-                                <img class="swish-img lazy" data-original="https://cdn-02.mondido.com/www/img/swish_tre_mobiler.png" alt="Swish"/>
-                            </div>
-                            <div class="row spacer col-xs-12">
-                                <input novalidate type="tel" autocomplete="cc-number" class="form-control cc-number" id="swish_number" name="swish_number" placeholder="4670112233" value="" tabindex="1" coolname="Telefonnummer" autofocus="true" />
-                                <label for="swish_number" class="mulang" data-mulang="your_mobile_number">>Your mobile number</label>
-                            </div>
-                            <div class="row spacer">
-                                <input id="paybtn-swish" class="btn btn-lg btn-success btn-block" type="submit" value="Betala" tabindex="5">
-                            </div>
-                        </form>
+  <div class="load-center mondido-load">
+    <div class="sk-circle">
+      <div class="sk-circle1 sk-child"></div>
+      <div class="sk-circle2 sk-child"></div>
+      <div class="sk-circle3 sk-child"></div>
+      <div class="sk-circle4 sk-child"></div>
+      <div class="sk-circle5 sk-child"></div>
+      <div class="sk-circle6 sk-child"></div>
+      <div class="sk-circle7 sk-child"></div>
+      <div class="sk-circle8 sk-child"></div>
+      <div class="sk-circle9 sk-child"></div>
+      <div class="sk-circle10 sk-child"></div>
+      <div class="sk-circle11 sk-child"></div>
+      <div class="sk-circle12 sk-child"></div>
+    </div>
+  </div>
 
-                    </div>
-                    <!-- /swish -->
-                    <!-- paypal-->
-                    <div role="tabpanel" class="tab-pane fade" id="paypal_tab" aria-labelledBy="paypal_tab" style="text-align: center;">
-                        <form action="" class="form-signin" id="paypalform" method="post" role="form">
-                            <input type="hidden" name="paypal" value="1" />
-                            <div class="row spacer">
-                                <div class="mulang" data-mulang="paypal_hl">Pay easily with PayPal</div>
-                                <img class="paypal-img" src="https://cdn-02.mondido.com/www/img/paypal-1.png" alt="PayPal logo"/>
-                            </div>
-                            <div class="row spacer">
-                                <input data-mulang="paypal_btn:value" id="paybtn-paypal" class="mulang btn btn-lg btn-success btn-block" type="submit" value="Betala med PayPal" tabindex="5">
-                            </div>
-                        </form>
-                    </div>
-                    <!-- /paypal-->
+  <div id="paymentArea" class="mondido-payment" style="display:none;">
+    <div id="payform" class="container">
 
-                    <!-- masterpass-->
-                    <div role="tabpanel" class="tab-pane fade" id="masterpass_tab" aria-labelledBy="masterpass_tab" style="text-align: center;">
-                        <form action="" class="form-signin" id="masterpassform" method="post" role="form">
-                            <input type="hidden" name="masterpass" value="1" />
-                            <div class="row spacer">
-                                <div style="margin-bottom:30px;">Pay with MasterPass</div>
-                                <a href="#" id="checkoutButtonDiv">
-                                <img class="lazy" data-original="https://cdn-02.mondido.com/www/img/mcpp_wllt_btn_chk_147x034px.png" alt="Buy with MasterPass" >
-                                </a>
-                            </div>
-                            <div id="mpspin" style="">
-                            </div>
-                            <div class="row spacer">
-                                <a href="http://www.mastercard.com/mc_us/wallet/learnmore/se/" target="_blank">Learn more about MasterPass</a>
-                            </div>
-                        </form>
+      {% if show_logo == true %}
+      <div class="m-layout-show-logo col-xs-12 text-center hidden">
+        <img class="m-layout-logo" src="https://cdn-02.mondido.com/pay-out/v2/img/mondido-logo.png" alt="Logo" />
+      </div>
+      {% endif %}
 
-                    </div>
-                    <!-- /masterpass-->
+      <div data-mulang="choose_payment_option" class="row text-center choose mulang text-choose-payment">
+        Please choose payment option
+      </div>
 
-                </div>
-            </div>
-        </div>
-        
-        <div class="row">
-            <div class="col-xs-12" style="text-align:center;">
-               <span class="" id="languages" ></span>
-            </div>
-        </div>
-
-
-        <div class="row" id="poweredBy">
-         <div class="col-xs-12" style="text-align:center;">
-            <span class="mulang" data-mulang="powered_by">Powered by</span>
-            <a href="https://www.mondido.com/en/about-us" target="_blank">
-                <img class="logo" src="https://cdn-02.mondido.com/www/img/mondido-payments-black-2016-2.png" alt="Logo" />
+      <!-- ######### Nav tabs ######### -->
+      <div role="tabpanel" id="payment-tabpanel">
+        <ul id="mondidoPaymentTab" class="nav nav-tabs" role="tablist" >
+          {% if show_credit_card == true %}
+          <li role="presentation" class="credit_card_tab" style="display:none;">
+            <a href="#credit_card_tab" aria-controls="credit_card_tab" role="tab" data-toggle="tab" class="card-tab">
+              {% if show_card_mastercard == true %}
+              <img class="" src="https://cdn-02.mondido.com/pay-out/v2/img/mastercard-logo.svg" alt="Mastercard logo"/>
+              {% endif %}
+              {% if show_card_visa == true %}
+              <img class="" src="https://cdn-02.mondido.com/pay-out/v2/img/visa-logo.svg" alt="Visa logo"/>
+              {% endif %}
+              <small data-mulang="card_payment" class="small_tab_text mulang">Card</small>
             </a>
-         </div>
-         </div>
+          </li>
+          {% endif %}
 
-        <div data-mulang="failed_message" id="try-again" class="hidden mulang">
-            Your payment was declined, please try again with a new card or verify your numbers.
-        </div>
-        <div data-mulang="validation_message" id="validation-error" class="hidden mulang">
-            All fields need to be filled in. Whats missing is:\n
-        </div>
-        <div data-mulang="card_not_accepted" id="badcard" class="hidden mulang">
-            {card} is not accepted
-        </div>
-        <div data-mulang="card_number" id="err_cardnumber" class="hidden mulang">
-            Card number,
-        </div>
-        <div data-mulang="card_holder" id="err_cardholder" class="hidden mulang">
-            Card holder name,
-        </div>
-        <div data-mulang="cvc" id="err_cvv" class="hidden mulang">
-            CVV/CVV2-code,
-        </div>
-        <div data-mulang="expiry" id="err_expiry" class="hidden mulang">
-            Expiry date
+          {% if show_swish == true %}
+          <li role="presentation" class="swish_tab" style="display:none;">
+            <a href="#swish_tab" aria-controls="swish_tab" role="tab" data-toggle="tab">
+            <img src="https://cdn-02.mondido.com/pay-out/v2/img/swish-logo.png" alt="Swish">
+              <small data-mulang="swish_payment" class="small_tab_text mulang">Swish</small>
+            </a>
+          </li>
+          {% endif %}
+
+          {% if show_trustly == true %}
+          <li role="presentation" class="trustly_tab" style="display:none;">
+            <a href="#trustly_tab" aria-controls="trustly_tab" role="tab" data-toggle="tab">
+              <img class="" src="https://cdn-02.mondido.com/pay-out/v2/img/trustly-logo.png" style="max-width: 50px;" alt="Trustly logo"/>
+              <small data-mulang="bank_payment" class="small_tab_text mulang">Bank</small>
+            </a>
+          </li>
+          {% endif %}
+
+          {% if show_paypal == true %}
+          <li role="presentation" class="paypal_tab" style="display:none;">
+            <a href="#paypal_tab" aria-controls="paypal_tab" role="tab" data-toggle="tab">
+              <img class="" src="https://cdn-02.mondido.com/pay-out/v2/img/paypal-logo.svg" style="max-width: 50px;" alt="PayPal logo"/>
+              <small data-mulang="paypal_payment" class="small_tab_text mulang">PayPal</small>
+            </a>
+          </li>
+          {% endif %}
+
+          {% if show_invoice == true %}
+          <li role="presentation" class="invoice_tab" style="display:none;">
+            <a href="#invoice_tab" aria-controls="invoice_tab" role="tab" data-toggle="tab" class="card-tab" >
+              <i class="fa fa-file-text-o"></i>
+              <small data-mulang="invoice_payment" class="small_tab_text mulang">Invoice</small>
+            </a>
+          </li>
+          {% endif %}
+
+          {% if show_masterpass == true %}
+          <li role="presentation" class="masterpass_tab" style="display:none;">
+            <a href="#masterpass_tab" aria-controls="masterpass_tab" role="tab" data-toggle="tab" class="tab" >
+              <img src="https://cdn-02.mondido.com/pay-out/v2/img/masterpass-logo.png" class="masterpass_img_tab" alt="Masterpass" />
+              <small class="small_tab_text masterpass_small_text mulang">Masterpass</small>
+            </a>
+          </li>
+          {% endif %}
+
+        </ul>
+      </div>
+      <!-- ######### Tab panes ######### -->
+      <div id="myTabsegmentation_toggleContent" class="row tab-content">
+        <div class="row header">
+          <div class="col-xs-12 text-center">
+            <p class="amount mulang" data-mulang="amount['{{ transaction.amount | round }}','{{ currency }}']">
+                {{ transaction.amount | round }} {{ currency }}
+            </p>
+            <div id="currencyConvert" class="col-xs-12 text-center hidden" style="margin-bottom:20px;"></div>
+            <div id="errors" class="alert alert-danger"></div>
+          </div>
         </div>
 
-        <script>
-          function load(script) {
-            document.write('<'+'script src="'+script+'" type="text/javascript"><' + '/script>');
-          }
+{% if show_credit_card == true %}
+<!-- card -->
+          <div role="tabpanel" class="tab-pane fade" id="credit_card_tab" aria-labelledBy="credit_card_tab">
+              <!-- ######### CARD ######### - ######### START ######### -->
+              <div class="row">
+              <form id="mondidopayform" class="form-signin" method="post" autocomplete="on" novalidate>
+                  <input type="hidden" name="card_expiry" id="card_expiry" value="" />
+                  <div class="card_holder_name">
+                    <label id="label_card_holder" data-mulang="card_holder" class="mulang">
+                        Card holder name:
+                    </label>
+                    <input id="input_card_holder" data-mulang="card_holder_placeholder:placeholder" placeholder="Firstname Lastname"  type="text" class="form-control mulang m-ent-tab" name="card_holder" value="{{ transaction.metadata['customer']['firstname'] }} {{ transaction.metadata['customer']['lastname'] }}" tabindex="1" autocomplete="cc-name" autofocus />
+                  </div>
+                  <label data-mulang="card_number" class="mulang">
+                      Card number:
+                  </label>
+                  <div class="card_number_div">
+                    <span class="cc-brand"></span>
+                      <input data-mulang="card_number_placeholder:placeholder" data-numeric type="tel" class="mulang form-control identified cc-number m-ent-tab" id="card_number" name="card_number" placeholder="•••• •••• •••• ••••" value="" maxlength="19" tabindex="2" />
+                      <div class="cards">
+                        <div data-mulang="card_not_accepted" class="arrow_box mulang">Card is currently not supported</div>
+                      </div>
+                  </div>
+                  <label hidden>
+                      Card Type
+                  </label>
+                  <input type="hidden" class="form-control" name="card_type" id="card_type"/>
+                  <div class="row">
+                    <div class="col-xs-4 nopadleft">
+                      <label data-mulang="exp_month" class="mulang">
+                          Month:
+                      </label>
+                      <input type="tel" class="form-control cc-exp cc-number m-ent-tab" maxlength="2" id="expMM" name="expMM" placeholder="01" tabindex="3" required pattern="\d*" />
+                    </div>
+                    <div class="col-xs-4">
+                      <label data-mulang="exp_year" class="mulang">
+                          Year:
+                      </label>
+                      <input type="tel" class="form-control cc-exp cc-number m-ent-tab" maxlength="2" id="expYY" name="expYY" placeholder="16" tabindex="4" required pattern="\d*" />
+                    </div>
+                    <div class="col-xs-4 nopadright">
+                      <label data-mulang="cvc" class="mulang">
+                          CVV:
+                      </label>
+                      <input type="tel" class="form-control cc-cvc cc-number" maxlength="4" id="card_cvv" name="card_cvv" placeholder="•••" tabindex="5" required pattern="\d*" autocomplete="off" />
+                    </div>
+                  </div>
+                  <input data-mulang="pay_button:value" id="paybtn-cc" class="mulang btn btn-lg btn-success btn-block" type="submit" value="Pay" tabindex="6"/>
+                  <div id="loading-cc" class="hidden">
+                    <span class="mulang" data-mulang="loading">Loading:</span>
 
-          load(mondidoSettings.config.system.lang_endpoint);
-          load(mondidoSettings.config.system.jquery_endpoint);
-          load(mondidoSettings.config.system.bootstrap_endpoint);
+                    <div class="sk-circle">
+                      <div class="sk-circle1 sk-child"></div>
+                      <div class="sk-circle2 sk-child"></div>
+                      <div class="sk-circle3 sk-child"></div>
+                      <div class="sk-circle4 sk-child"></div>
+                      <div class="sk-circle5 sk-child"></div>
+                      <div class="sk-circle6 sk-child"></div>
+                      <div class="sk-circle7 sk-child"></div>
+                      <div class="sk-circle8 sk-child"></div>
+                      <div class="sk-circle9 sk-child"></div>
+                      <div class="sk-circle10 sk-child"></div>
+                      <div class="sk-circle11 sk-child"></div>
+                      <div class="sk-circle12 sk-child"></div>
+                    </div>
+                  </div>
+                  <div class="footer">
+                    <div class="row text-center">
+                      <div class="col-xs-6">
+                        {% if show_card_visa == true %}
+                          <img class="card-img" src="https://cdn-02.mondido.com/pay-out/v2/img/visa-logo.svg" style="max-width: 40px;" alt="Visa logo"/>
+                        {% endif %}
 
-          if (mondidoSettings.config.development == true){
-            load("js/mondido.payment.js");
-          } else {
-            load(mondidoSettings.config.system.payment_js_endpoint);
-          }
+                        {% if show_card_mastercard == true %}
+                          <img class="card-img" src="https://cdn-02.mondido.com/pay-out/v2/img/mastercard-logo.svg" style="max-width: 40px;" alt="Mastercard"/>
+                        {% endif %}
 
-          load(mondidoSettings.config.system.fontawesome);
-          //load("https://static.masterpass.com/lightbox/Switch/integration/MasterPass.client.js");
-          //load("https://masterpass.com/lightbox/Switch/assets/js/MasterPass.omniture.js");
+                        {% if show_card_amex == true %}
+                          <img class="card-img" src="https://cdn-02.mondido.com/pay-out/v2/img/americanexpress-logo.svg" style="max-width: 40px;" alt="American Express logo"/>
+                        {% endif %}
+                      </div>
+                      <div class="col-xs-6">
+                        <img class="card-img" src="https://cdn-02.mondido.com/pay-out/v2/img/3dsecure.png" alt="3d secure"/>
+                      </div> </div>
+                      <div class="comodotext mulang" data-mulang="safe_text">
+Your payment is made safe by Mondido. The store will never be in contact with your credit card information, all the information is sent encrypted to your bank. Mondido is PCI DSS Level 1 certified and use HTTPS / TLS, which is the banking industry standard for secure e-commerce transactions.
+                      </div>
+                  </div>
+                  <p class="clearfix">
+                  </p>
+              </form>
+              </div>
+              <!-- ######### CARD ######### - ######### END ######### -->
+          </div>
+<!-- /card -->
+{% endif %}
 
-        </script>
+{% if show_trustly == true %}
+<!-- trustly -->
+          <div role="tabpanel" class="tab-pane fade" id="trustly_tab" aria-labelledBy="trustly_tab" style="text-align: center;">
+            <!-- ######### Trustly ######### - ######### START ######### -->
+            <form action="javascript:void(0);" id="trustlyform" method="post"  target="trustly">
+              <input type="hidden" name="trustly" value="1" />
+              <input type="hidden" name="trustly_locale" value="sv_SE" />
+              <input type="hidden" name="trustly_country" value="SE" />
+            </form>
 
-    </body>
+            <iframe src="" name="trustly" height="400" style="border: 0; width:95%; "></iframe>
+            <div class="mulang" data-mulang="what_is_trustly">What is Trustly?</div>
+            <!-- ######### TRUSTLY ######### - ######### END ######### -->
+          </div>
+ <!-- /trustly -->
+{% endif %}
+
+{% if show_swish == true %}
+<!-- swish -->
+          <div role="tabpanel" class="tab-pane fade" id="swish_tab" aria-labelledBy="swish_tab" style="text-align: center;">
+            <!-- ######### SWISH ######### - ######### START ######### -->
+            <form action="javascript:void(0);" class="form-signin go-bottom" id="swishform" method="post" >
+              <input type="hidden" name="swish" value="1" />
+              <div class="row">
+                <div class="mulang" data-mulang="easily_pay_with_swish_mobile">Pay with Swish Mobile</div>
+                <img class="swish-img " src="https://cdn-02.mondido.com/www/img/swish_tre_mobiler.png" alt="Swish"/>
+              </div>
+              <div class="row spacer col-xs-12">
+                <input type="tel"  class="form-control cc-number" id="swish_number" name="swish_number" placeholder="4670112233" value="" tabindex="1" />
+                <label for="swish_number" class="mulang" data-mulang="your_mobile_number">>Your mobile number</label>
+              </div>
+              <div class="row spacer">
+                <input id="paybtn-swish" class="btn btn-lg btn-success btn-block" type="submit" value="Betala" tabindex="5">
+              </div>
+            </form>
+            <!-- ######### SWISH ######### - ######### END ######### -->
+          </div>
+<!-- /swish -->
+{% endif %}
+
+{% if show_paypal == true %}
+<!-- paypal-->
+          <div role="tabpanel" class="tab-pane fade" id="paypal_tab" aria-labelledBy="paypal_tab" style="text-align: center;">
+              <!-- ######### PAYPAL ######### - ######### START ######### -->
+              <form action="javascript:void(0);" class="form-signin" id="paypalform" method="post" >
+                <input type="hidden" name="paypal" value="1" />
+                <div class="row spacer">
+                  <div class="mulang" data-mulang="paypal_hl">Pay easily with PayPal</div>
+                  <img class="" src="https://cdn-02.mondido.com/pay-out/v2/img/paypal-logo.svg"  style="max-width: 200px;" alt="PayPal logo"/>
+                </div>
+                <div class="row spacer">
+                  <input data-mulang="paypal_btn:value" id="paybtn-paypal" class="mulang btn btn-lg btn-success btn-block" type="submit" value="Betala med PayPal" tabindex="5">
+                </div>
+              </form>
+              <!-- ######### PAYPAL ######### - ######### END ######### -->
+          </div>
+<!-- /paypal-->
+{% endif %}
+
+{% if show_masterpass == true %}
+<!-- masterpass-->
+          <div role="tabpanel" class="tab-pane fade" id="masterpass_tab" aria-labelledBy="masterpass_tab" style="text-align: center;">
+            <!-- ######### MASTERPASS ######### - ######### START ######### -->
+            <form action="javascript:void(0);" class="form-signin" id="masterpassform" method="post" >
+              <input type="hidden" name="masterpass" value="1" />
+              <div class="row spacer">
+                <div style="margin-bottom:25px;">Pay with MasterPass</div>
+                <a href="#" id="checkoutButtonDiv">
+                  <img src="https://cdn-02.mondido.com/pay-out/v2/img/buttons/masterpass_btn.png" alt="Buy with MasterPass" >
+                </a>
+              </div>
+              <div id="mpspin" style=""></div>
+              <div class="row spacer">
+                <a href="http://www.mastercard.com/mc_us/wallet/learnmore/se/" target="_blank">Learn more about MasterPass</a>
+              </div>
+            </form>
+            <!-- ######### MASTERPASS ######### - ######### END ######### -->
+          </div>
+<!-- /masterpass-->
+{% endif %}
+
+{% if show_invoice == true %}
+<!-- invoice -->
+          <div role="tabpanel" class="tab-pane fade" id="invoice_tab" aria-labelledBy="invoice_tab">
+            <!-- ######### INVOICE ######### - ######### START ######### -->
+            <form id="invoiceform" class="form-signin go-bottom" method="post" >
+                <input type="hidden" id="payment_method" name="payment_method"/>
+                <input type="hidden" id="country_code" name="country_code" value="{{ transaction.payment_details.country_code }}"/>
+                <input type="hidden" id="pending_payment_customer" name="pending_payment_customer"/>
+                <input type="hidden" id="segmentation" name="segmentation" value="{{{ transaction.payment_details.segmentation }}" />
+
+                <div class="row hidden" id="segmentation_toggle" style="margin-bottom:5px;">
+                  <div class="row pull-right">
+                    <button type="button" id="b2c" data-value="b2c" class="segmentation_select btn btn-sm"><span class="mulang" data-mulang="individual">Individual</span></button>
+                    <button type="button" id="b2b" data-value="b2b" class="segmentation_select btn btn-sm"><span class="mulang" data-mulang="business">Business</span></button>
+                  </div>
+                </div>
+
+                <div class="row spacer" id="row-email">
+                  <div class="row">
+                    <div class="col-xs-12">
+                      <input type="text" class="form-control next-email mulang m-ent-tab" maxlength="255" id="email" name="email" placeholder="Your email address" tabindex="1" value="{{ transaction.payment_details.email }}" autocomplete="email" autofocus />
+                       <label for="email" data-mulang="your_email_address" class="mulang ">Your email address</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row hidden spacer" id="row-phone-details">
+                  <div class="row">
+                    <div class="col-xs-12">
+                      <input data-numeric type="tel" class="form-control next-phone mulang m-ent-tab" id="phone" name="phone" placeholder="Your phone number" value="{{ transaction.payment_details.phone }}" maxlength="20" tabindex="2"   />
+                       <label for="phone" data-mulang="your_phone_number" class="mulang">Your phone number</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row hidden spacer" id="row-ssn-details">
+                  <div class="row">
+                    <div class="col-xs-12">
+                      <input data-numeric type="tel" class="form-control next-ssn mulang m-ent-tab" id="ssn" name="ssn" placeholder="ååååmmdd ••••" value="{{ transaction.payment_details.ssn }}" maxlength="13" tabindex="3"  />
+                       <label for="ssn" data-mulang="your_social_security_number" class="mulang">Your Social Security number</label>
+                    </div>
+                  </div>
+                </div>
+                <div class="row hidden" id="row-ssn-details-loading">
+                  <div class="row">
+                    <div class="col-xs-12 mulang" id="loading" data-mulang="loading">
+                        Loading
+                    </div>
+                     <div class="col-xs-12">
+
+                      <div class="sk-circle" style=" margin: 20px auto;">
+                        <div class="sk-circle1 sk-child"></div>
+                        <div class="sk-circle2 sk-child"></div>
+                        <div class="sk-circle3 sk-child"></div>
+                        <div class="sk-circle4 sk-child"></div>
+                        <div class="sk-circle5 sk-child"></div>
+                        <div class="sk-circle6 sk-child"></div>
+                        <div class="sk-circle7 sk-child"></div>
+                        <div class="sk-circle8 sk-child"></div>
+                        <div class="sk-circle9 sk-child"></div>
+                        <div class="sk-circle10 sk-child"></div>
+                        <div class="sk-circle11 sk-child"></div>
+                        <div class="sk-circle12 sk-child"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="row hidden" id="row-ssn-details-error">
+                  <div class="row">
+                    <div class="col-xs-12 error mulang" data-mulang="invoice_address_could_not_be_retrieved">
+                        Your address could not be retrieved. Check that you have entered the correct Social Security number. Example 198605141234
+                    </div>
+                  </div>
+                </div>
+                <div class="row hidden" id="row-customer-details">
+                  <div class="row spacer">
+                    <div class="col-xs-6">
+                      <input type="text" data-mulang="first_name:placeholder" class="form-control mulang invoice-input m-ent-tab" maxlength="12" id="first_name" name="first_name" placeholder="First name" tabindex="4" value="{{ transaction.payment_details.mask_first_name }}" disabled/>
+                      <label for="first_name" data-mulang="first_name" class="mulang">First name</label>
+                    </div>
+                    <div class="col-xs-6">
+                      <input type="text" data-mulang="last_name:placeholder" class="form-control mulang invoice-input m-ent-tab" maxlength="12" id="last_name" name="last_name" placeholder="Last name" tabindex="4" value="{{ transaction.payment_details.mask_last_name }}" disabled/>
+                      <label for="last_name" data-mulang="last_name" class="mulang">Last name</label>
+                    </div>
+                  </div>
+                  <div class="row spacer">
+                    <div class="col-xs-12">
+                      <div class="address">
+                        <input data-text data-mulang="address:placeholder"  type="text" class="form-control mulang invoice-input m-ent-tab" id="address_1" name="address_1" value="{{ transaction.payment_details.mask_address_1 }}" maxlength="255" placeholder="Address" tabindex="5" disabled/>
+                        <label for="address_1" data-mulang="address" class="mulang">Address</label>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="row spacer hidden invoice-address-2">
+                    <div class="col-xs-12">
+                      <div class="address">
+                        <input data-text data-mulang="co_address:placeholder"  type="text" class="form-control mulang invoice-input m-ent-tab" id="address_2" name="address_2" value="{{ transaction.payment_details.mask_address_2 }}" maxlength="255" placeholder="C/O Adress" tabindex="6" disabled/>
+                        <label for="address_2" data-mulang="co_address" class="mulang">C/O Adress</label>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="row spacer">
+                    <div class="col-xs-6">
+                      <input type="text" data-mulang="zip:placeholder" class="form-control mulang invoice-input m-ent-tab" maxlength="12" id="zip" name="zip" placeholder="zip" tabindex="7" value="{{ transaction.payment_details.mask_zip }}" disabled/>
+                      <label for="zip" data-mulang="zip" class="mulang">Zip code</label>
+                    </div>
+                    <div class="col-xs-6">
+                      <input type="text" data-mulang="city:placeholder" class="form-control mulang invoice-input m-ent-tab" maxlength="255" id="city" name="city" placeholder="City" tabindex="8" value="{{ transaction.payment_details.mask_city }}" disabled/>
+                      <label for="city" data-mulang="city" class="mulang">City</label>
+                    </div>
+                  </div>
+
+                  <div class="row ">
+                    <div class="col-xs-2">
+                      <label class="bigcheck">
+                        <input type="checkbox" class="bigcheck mulang" name="cheese" value="yes"  data-mulang="i_accept:placeholder" tabindex="9"  />
+                        <span class="bigcheck-target"></span>
+                      </label>
+                    </div>
+                    <div class="col-xs-10">
+                      <span id="accept_collector" class="mulang accept_collector" data-mulang="invoice_accept_conditions['']" style="font-size: 12px;">
+                        Yes, I have read and accept Collector Bank\'s
+                        <a target="new" href="https://www.collector.se/upload/Partners/Agreements/AgreementCode/Credit_terms_All_SE.pdf">
+                        General Conditions For Invoice And Credit Accounts </a>
+                        and
+                        <a target="new" href="http://www.collector.se/upload/Partners/Agreements/AgreementCode/SECCI_SE.pdf"> Standardised European Consumer Credit Information </a> ,
+                        and <a target="new" href="url">
+                        Conditions #COPAMNY# </a>
+                      </span>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <input data-mulang="pay_button:value" id="paybtn" class="btn btn-lg btn-success btn-block mulang" type="submit" value="Pay" tabindex="9"/>
+                  </div>
+                </div>
+
+                <div class="row footer comodotext" id="invoice_foot">
+                  <div class="text-center">
+                    <img class="" src="https://cdn-02.mondido.com/pay-out/v2/img/collector-bank-logo.svg" style="max-width: 200px;" alt="Collector bank logo"/>
+                  </div>
+                  <span class="mulang" data-mulang="invoice_footer_conditions" >
+                      When you select the invoice you will receive your goods before you pay. You can then choose to pay the whole amount at once or split the payment into smaller parts . In order to deal with the bill collectors will be at least 18 years. The invoice will be sent by e-mail. More information can be found at
+                  </span> <a target="new" href="https://www.collector.se">https://www.collector.se</a>
+                </div>
+            </form>
+            <!-- ######### INVOICE ######### - ######### END ######### -->
+          </div>
+<!-- /invoice -->
+{% endif %}
+
+      </div>
+    </div>
+  </div>
+
+  <div class="row mondido-payment" style="display:none;">
+      <div class="col-xs-12" style="text-align:center;">
+         <span class="" id="languages" ></span>
+      </div>
+  </div>
+
+{% if show_powered_by == true %}
+  <div class="row mondido-payment" id="poweredBy" style="display:none;">
+    <div class="col-xs-12" style="text-align:center;">
+      <span class="mulang" data-mulang="powered_by">Powered by</span>
+      <a href="https://www.mondido.com/en/about-us" target="_blank">
+        <img class="logo" src="https://cdn-02.mondido.com/pay-out/v2/img/mondido-logo.png" alt="Logo" />
+      </a>
+    </div>
+  </div>
+{% endif %}
+
+{% if show_credit_card == true %}
+  <div data-mulang="failed_message" id="try-again" class="hidden mulang">
+      Your payment was declined, please try again with a new card or verify your numbers.
+  </div>
+  <div data-mulang="validation_message" id="validation-error" class="hidden mulang">
+      All fields need to be filled in. Whats missing is:\n
+  </div>
+  <div data-mulang="card_not_accepted" id="badcard" class="hidden mulang">
+      {card} is not accepted
+  </div>
+  <div data-mulang="card_number" id="err_cardnumber" class="hidden mulang">
+      Card number,
+  </div>
+  <div data-mulang="card_holder" id="err_cardholder" class="hidden mulang">
+      Card holder name,
+  </div>
+  <div data-mulang="cvc" id="err_cvv" class="hidden mulang">
+      CVV/CVV2-code,
+  </div>
+  <div data-mulang="expiry" id="err_expiry" class="hidden mulang">
+      Expiry date
+  </div>
+{% endif %}
+
+  <script>
+    function load(script) {
+      document.write('<'+'script src="'+script+'" type="text/javascript"><' + '/script>');
+    }
+
+    load(mondidoSettings.config.system.lang_endpoint);
+    load(mondidoSettings.config.system.payment_js_endpoint);
+  </script>
+
+{% if show_invoice == true %}
+  <script>
+    load(mondidoSettings.config.system.fontawesome);
+  </script>
+{% endif %}
+
+
+{% if show_masterpass == true %}
+  <script>
+    load("https://static.masterpass.com/lightbox/Switch/integration/MasterPass.client.js");
+    load("https://masterpass.com/lightbox/Switch/assets/js/MasterPass.omniture.js");
+  </script>
+{% endif %}
+
+<script type="text/javascript">
+$( document ).ready(function() {
+  console.log( "mondido-payment ready!" );
+  $('.mondido-load').hide();
+  $('.mondido-payment').fadeIn(500);
+});
+</script>
+  </body>
 </html>


### PR DESCRIPTION
Update to v2
- \- Update pay-out version to 2.0
-   - mondido.payment.js and multi.css will follow pay-out version.
-     If "pay-out" is 2.1 "mondido.payment.js" and "multi.css" shuld be of version 2.1.x
-     Example "mondido.payment.js" is of version 2.1.x.x it should be compatible with "pay-out" version to 2.1.x
- \- Add MIT License
- \- Move changelog
- \- Fix wc3 validation
- \- Fix css/js bugs
- \- Update images
- \- Add metadata preload data
- \- Add convertCurrency
- \- Update CSS
- \- Update JS
- \- Change/Update design
- \- Change Enter to tab if @ input
- \- Use liquid to only load the necessary html code
- \- Add liquid settings from mondido to easy setup
- \- Optimization
- \- convention
- \- Start to use css class convention (.mo-exaple-ex2-test)
- \- Start to use indent spaces 2 and
- \- Use transaction.merchant.settings_hosted 4 settings
